### PR TITLE
Fixes "Unknown column type json requested."

### DIFF
--- a/Resources/config/doctrine/Message.orm.xml
+++ b/Resources/config/doctrine/Message.orm.xml
@@ -10,7 +10,7 @@
         </id>
 
         <field name="type"         type="string"     column="type" length="255"/>
-        <field name="body"         type="json"       column="body" />
+        <field name="body"         type="array"       column="body" />
         <field name="state"        type="integer"    column="state"  />
         <!--<field name="group"        type="string"     column="group"   />-->
 


### PR DESCRIPTION
When you install SonataNotificationBundle and then attempt to make an update to doctrine, it fails in Symfony 2.0.12 with Unknown column type json requested.

The message entity's body attribute should be an array according to the model. If it's supposed to be json then a new doctrine type should be created for this.

This resolves issue #4
