### PR TITLE
fixed all the sonata namespaces

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -35,10 +35,10 @@ Update the ``autoload.php`` to add new namespaces:
     <?php
     $loader->registerNamespaces(array(
         'Sonata'          => array(
-            __DIR__ .'/../vendor',
-            __DIR__.'/../sonata-doctrine-extensions',
+            __DIR__ .'/../vendor/bundles',
+            __DIR__.'/../vendor/sonata-doctrine-extensions/src',
         ),
-        'PhpAmqpLib'      => __DIR__ . '/../vendor/php-amqplib',
+        'PhpAmqpLib'      => __DIR__ . '/../vendor/php-amqplib/PhpAmqpLib',
         // ... other declarations
     ));
 


### PR DESCRIPTION
to me works also
in this way

not tested :(

```
'Sonata\\Doctrine' => __DIR__.'/../vendor/sonata-doctrine-extensions/src',
'Sonata'          => __DIR__.'/../vendor/bundles',

'PhpAmqpLib'      => __DIR__ . '/../vendor/php-amqplib/PhpAmqpLib',
```
