### PR TITLE
Exception object correctly re-thrown

### DIFF
--- a/Consumer/SwiftMailerConsumer.php
+++ b/Consumer/SwiftMailerConsumer.php
@@ -48,7 +48,7 @@ class SwiftMailerConsumer implements ConsumerInterface
         $this->mailer->getTransport()->stop();
 
         if ($exception) {
-            throw new $exception;
+            throw $exception;
         }
     }
 


### PR DESCRIPTION
Code like this causes Warning: Missing argument...
$e = new \Exception('Foo');
throw new $e; //should be "throw $e" - without the "new" keyword
