### PR TITLE
Commit #c922173 introduced Error Exception in PostponeRuntimeBackend.php

### DIFF
--- a/Backend/PostponeRuntimeBackend.php
+++ b/Backend/PostponeRuntimeBackend.php
@@ -53,9 +53,11 @@ class PostponeRuntimeBackend extends RuntimeBackend
      */
     public function onEvent(Event $event = null)
     {
-        foreach ($this->messages as $eachMessage) {
-            $this->handle($eachMessage, $this->dispatcher);
-        }
+    	if (is_array($this->messages)) {
+        	foreach ($this->messages as $eachMessage) {
+            	$this->handle($eachMessage, $this->dispatcher);
+        	}
+    	}
     }
 
     /**


### PR DESCRIPTION
After updating the SonataNotificationBundle in our Symfony 2.1 project to commit #c922173 we continually got the following error exception:

ErrorException: Warning: Invalid argument supplied for foreach() in
vendor/sonata-project/notification-bundle/Sonata/NotificationBundle/Backend/PostponeRuntimeBackend.php
line 56

This was being cause by the fact that the foreach was trying to loop through $this->messages which was NOT an array. I simply put an array check around the call to prevent the foreach from being executed if the $messages variable is not an array.
