### PR TITLE
added message initialization for PostponeRuntimeBackend

### DIFF
--- a/Backend/PostponeRuntimeBackend.php
+++ b/Backend/PostponeRuntimeBackend.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\NotificationBundle\Backend;
 
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
 use Sonata\NotificationBundle\Backend\BackendStatus;
 use Sonata\NotificationBundle\Iterator\IteratorProxyMessageIterator;
 use Sonata\NotificationBundle\Model\MessageInterface;
@@ -30,6 +32,15 @@ class PostponeRuntimeBackend extends RuntimeBackend
      * @var MessageInterface[]
      */
     protected $messages;
+
+    /**
+     * @param EventDispatcherInterface $dispatcher
+     */
+    public function __construct(EventDispatcherInterface $dispatcher)
+    {
+        parent::__construct($dispatcher);
+        $this->messages = array();
+    }
 
     /**
      * Publish a message by adding it to the local storage.


### PR DESCRIPTION
The PostponeRuntimeBackend caused an error in our app due to the fact that the `messages` array was never initialized. 

Not sure if i missed something in the config, but this patch should make sure that the array is initialized properly.
