### PR TITLE
added recover option for rabbitmq backend

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -99,6 +99,7 @@ class Configuration implements ConfigurationInterface
             ->scalarNode('queue')->cannotBeEmpty()->isRequired()->end()
             ->scalarNode('routing_key')->defaultValue('')->end()
             ->booleanNode('default')->defaultValue(false)->end()
+            ->booleanNode('recover')->defaultValue(false)->end()
         ->end();
 
         return $node;

--- a/DependencyInjection/SonataNotificationExtension.php
+++ b/DependencyInjection/SonataNotificationExtension.php
@@ -111,7 +111,7 @@ class SonataNotificationExtension extends Extension
         } else {
             $defaultSet = false;
             foreach ($queues as $pos => $queue) {
-                $id = $this->createAMQPBackend($container, $exchange, $queue['queue'], $queue['routing_key']);
+                $id = $this->createAMQPBackend($container, $exchange, $queue['queue'], $queue['recover'], $queue['routing_key']);
                 $amqBackends[$pos] = array('type' => $queue['routing_key'], 'backend' =>  new Reference($id));
                 if ($queue['default'] === true) {
                     if ($defaultSet === true) {
@@ -140,14 +140,14 @@ class SonataNotificationExtension extends Extension
      * @param string $key
      * @return string
      */
-    protected function createAMQPBackend(ContainerBuilder $container, $exchange, $name, $key = '')
+    protected function createAMQPBackend(ContainerBuilder $container, $exchange, $name, $recover, $key = '')
     {
         if ($key === '') {
             $id = 'sonata.notification.backend.rabbitmq.default' . $this->amqpCounter++;
         } else {
             $id = 'sonata.notification.backend.rabbitmq.' . $key;
         }
-        $definition = new Definition('Sonata\NotificationBundle\Backend\AMQPBackend', array($exchange, $name, $key));
+        $definition = new Definition('Sonata\NotificationBundle\Backend\AMQPBackend', array($exchange, $name, $recover, $key));
         $definition->setPublic(false);
         $container->setDefinition($id, $definition);
 

--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -25,9 +25,12 @@ Full configuration options:
                     error:       20
                     open:        100
                     done:        10000
-
             rabbitmq:
                 exchange:     router
+			    queues: 
+			        # if `recover` is set to true, the consumer will respond with a `basic.recover` when an exception occurs
+			        # otherwise it will not respond at all and the message will be unacknowledged
+			       - { queue: defaultQueue, recover: true|false, default: true|false, routing_key: the_routing_key}
                 connection:
                     host:     localhost
                     user:     guest


### PR DESCRIPTION
In the current implementation when an exception occurs during message processing, the rabbitmq backend does not send back any response to the broker. 

If you have set the consumer to more than one iteration, this means that the message will not be re-broadcasted to the consumer until the end of the iteration cycle has been reached. 

This PR allows to configure a rabbitmq queue to send back a  `basic_recover` to the broker, which will make the message be re-broadcasted immediately. 
