### PR TITLE
Added support for rabbitmq dead letter exchanges, refs #39

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -101,6 +101,7 @@ class Configuration implements ConfigurationInterface
             ->scalarNode('routing_key')->defaultValue('')->end()
             ->booleanNode('default')->defaultValue(false)->end()
             ->booleanNode('recover')->defaultValue(false)->end()
+            ->scalarNode('dead_letter_exchange')->defaultValue(null)->end()
         ->end();
 
         return $node;

--- a/DependencyInjection/SonataNotificationExtension.php
+++ b/DependencyInjection/SonataNotificationExtension.php
@@ -113,7 +113,7 @@ class SonataNotificationExtension extends Extension
         } else {
             $defaultSet = false;
             foreach ($queues as $pos => $queue) {
-                $id = $this->createAMQPBackend($container, $exchange, $queue['queue'], $queue['recover'], $queue['routing_key']);
+                $id = $this->createAMQPBackend($container, $exchange, $queue['queue'], $queue['recover'], $queue['routing_key'], $queue['dead_letter_exchange']);
                 $amqBackends[$pos] = array('type' => $queue['routing_key'], 'backend' =>  new Reference($id));
                 if ($queue['default'] === true) {
                     if ($defaultSet === true) {
@@ -140,16 +140,17 @@ class SonataNotificationExtension extends Extension
      * @param ContainerBuilder $container
      * @param string $name
      * @param string $key
+     * @param string $deadLetterExchange
      * @return string
      */
-    protected function createAMQPBackend(ContainerBuilder $container, $exchange, $name, $recover, $key = '')
+    protected function createAMQPBackend(ContainerBuilder $container, $exchange, $name, $recover, $key = '', $deadLetterExchange = null)
     {
         if ($key === '') {
             $id = 'sonata.notification.backend.rabbitmq.default' . $this->amqpCounter++;
         } else {
             $id = 'sonata.notification.backend.rabbitmq.' . $key;
         }
-        $definition = new Definition('Sonata\NotificationBundle\Backend\AMQPBackend', array($exchange, $name, $recover, $key));
+        $definition = new Definition('Sonata\NotificationBundle\Backend\AMQPBackend', array($exchange, $name, $recover, $key, $deadLetterExchange));
         $definition->setPublic(false);
         $container->setDefinition($id, $definition);
 

--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -31,7 +31,9 @@ Full configuration options:
 			    queues: 
 			        # if `recover` is set to true, the consumer will respond with a `basic.recover` when an exception occurs
 			        # otherwise it will not respond at all and the message will be unacknowledged
-			       - { queue: defaultQueue, recover: true|false, default: true|false, routing_key: the_routing_key}
+                 #
+                 # if dead_letter_exchange is set,failed messages will be rejected and sent to this exchange 
+			       - { queue: defaultQueue, recover: true|false, default: true|false, routing_key: the_routing_key, dead_letter_exchange: 'my.dead.letter.exchange'}
                 connection:
                     host:     localhost
                     user:     guest


### PR DESCRIPTION
By setting a `dead_letter_exchange` for an amqp queue, failed messages will be rejected and sent to the dead letter exchange declared by the parameter.
