### PR TITLE
fixed dead-letter-queue feature

### DIFF
--- a/Backend/AMQPBackend.php
+++ b/Backend/AMQPBackend.php
@@ -193,7 +193,7 @@ class AMQPBackend implements BackendInterface
             if ($this->recover === true) {
                 $message->getValue('AMQMessage')->delivery_info['channel']->basic_recover($message->getValue('AMQMessage')->delivery_info['delivery_tag']);
             } else if ($this->deadLetterExchange !== null) {
-                $message->getValue('AMQMessage')->delivery_info['channel']->basic_reject($message->getValue('AMQMessage')->delivery_info['delivery_tag']);
+                $message->getValue('AMQMessage')->delivery_info['channel']->basic_reject($message->getValue('AMQMessage')->delivery_info['delivery_tag'], false);
             }
 
             throw new HandlingException("Error while handling a message", 0, $e);


### PR DESCRIPTION
The second argument to [`basic_reject()`](https://github.com/videlalvaro/php-amqplib/blob/master/PhpAmqpLib/Channel/AMQPChannel.php#L682) was missing.

See http://www.rabbitmq.com/blog/2010/08/03/well-ill-let-you-go-basicreject-in-rabbitmq/
