### PR TITLE
Call to undefined method  JMSDiExtraExtension::blacklistControllerFile()

### DIFF
--- a/SonataNotificationBundle.php
+++ b/SonataNotificationBundle.php
@@ -21,16 +21,6 @@ class SonataNotificationBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new NotificationCompilerPass());
-
-        if ($container->hasExtension('jms_di_extra')) {
-            $container
-                ->getExtension('jms_di_extra')
-                ->blacklistControllerFile(
-                    $container->getParameter('kernel.root_dir') .
-                    '/../vendor/sonata-project/notification-bundle/Sonata/NotificationBundle/Controller/MessageAdminController.php'
-                )
-            ;
-        }
     }
 
     public function boot()


### PR DESCRIPTION
This reverts commit 1d9462fcec356c5a3773d4a06100487af6313dbd.

Fatal error: Call to undefined method JMS\DiExtraBundle\DependencyInjection\JMSDiExtraExtension::blacklistControllerFile()

this commit broke with JMSDiExtraBundle dev-master because blacklist is in a different branch (https://github.com/lsmith77/JMSDiExtraBundle/blob/controller_blacklist/DependencyInjection/JMSDiExtraExtension.php)
