### PR TITLE
Fixed queues key in advanced_configuration.rst

### DIFF
--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -28,12 +28,6 @@ Full configuration options:
                     done:        10000
             rabbitmq:
                 exchange:     router
-                queues:
-                    # if `recover` is set to true, the consumer will respond with a `basic.recover` when an exception occurs
-                    # otherwise it will not respond at all and the message will be unacknowledged
-                 #
-                 # if dead_letter_exchange is set,failed messages will be rejected and sent to this exchange
-                    - { queue: defaultQueue, recover: true|false, default: true|false, routing_key: the_routing_key, dead_letter_exchange: 'my.dead.letter.exchange'}
                 connection:
                     host:     localhost
                     user:     guest
@@ -41,7 +35,12 @@ Full configuration options:
                     port:     5672
                     vhost:    /
                     console_url : http://some.other.host:55999/api
-
+        queues:
+            # if `recover` is set to true, the consumer will respond with a `basic.recover` when an exception occurs
+            # otherwise it will not respond at all and the message will be unacknowledged
+            #
+            # if dead_letter_exchange is set,failed messages will be rejected and sent to this exchange
+            - { queue: defaultQueue, recover: true|false, default: true|false, routing_key: the_routing_key, dead_letter_exchange: 'my.dead.letter.exchange'}
     doctrine:
         orm:
             entity_managers:


### PR DESCRIPTION
The queues settings were under rabbitmq, but should have been under sonata_notification.
