### PR TITLE
Fix fatal error in cleanup command.

### DIFF
--- a/Entity/MessageManager.php
+++ b/Entity/MessageManager.php
@@ -164,7 +164,7 @@ class MessageManager implements MessageManagerInterface
             ->delete()
             ->where('message.state = :state')
             ->andWhere('message.completedAt < :date')
-            ->setParameter('state', Message::STATE_DONE)
+            ->setParameter('state', MessageInterface::STATE_DONE)
             ->setParameter('date', $date);
 
         $qb->getQuery()->execute();


### PR DESCRIPTION
Message class does not exist in this scope, so the cleanup command ends in a fatal PHP error.
