### PR TITLE
getEntityManager() is deprecated since Symfony 2.1.

### DIFF
--- a/Command/ConsumerHandlerCommand.php
+++ b/Command/ConsumerHandlerCommand.php
@@ -121,7 +121,7 @@ class ConsumerHandlerCommand extends ContainerAwareCommand
     private function optimize()
     {
         if ($this->getContainer()->has('doctrine')) {
-            $this->getContainer()->get('doctrine')->getEntityManager()->getUnitOfWork()->clear();
+            $this->getContainer()->get('doctrine')->getManager()->getUnitOfWork()->clear();
         }
     }
 


### PR DESCRIPTION
see https://github.com/doctrine/DoctrineBundle/blob/master/Registry.php#L71
