### PR TITLE
Fixing an issue occuring with php 5.3

### DIFF
--- a/Backend/QueueBackendDispatcher.php
+++ b/Backend/QueueBackendDispatcher.php
@@ -126,29 +126,4 @@ abstract class QueueBackendDispatcher implements QueueDispatcherInterface, Backe
     {
         return new CheckResult("backend health check", $message, $status);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public abstract function getIterator();
-
-    /**
-     * {@inheritdoc}
-     */
-    public abstract  function initialize();
-
-    /**
-     * {@inheritdoc}
-     */
-    public abstract function handle(MessageInterface $message, EventDispatcherInterface $dispatcher);
-
-    /**
-     * {@inheritdoc}
-     */
-    public abstract function getStatus();
-
-    /**
-     * {@inheritdoc}
-     */
-    public abstract function cleanup();
 }


### PR DESCRIPTION
Implementing interfaces methods as abstracts in an abstract class doesn't work with PHP 5.3 (it does with 5.4 however). Removing those methods abstract implementations fixes this.
