### PR TITLE
deploy:symlink no more exists since capistrano 2.10, use create_symlink instead

### DIFF
--- a/Resources/doc/reference/command_line.rst
+++ b/Resources/doc/reference/command_line.rst
@@ -30,7 +30,7 @@ Supervisor is a client/server system that allows its users to monitor and contro
 
 If you are deploying with capistrano, you can restart the supervisor process with a custom task::
 
-    after "deploy:symlink" do
+    after "deploy:create_symlink" do
         run "supervisorctl -u user -p password restart sonata_production_sonata_notification"
     end
     
@@ -54,9 +54,9 @@ Restart erroneous messages
 In case of getting messages with an erroneous status, you can reset their statuses and they will be reprocessed during
 the next iteration (this command must be used for the database backend)::
 
-    app/console sonata:notification:restart --type="xxx" --type="yyy" --max-attempts=10
+    app/console sonata:notification:restart --type="xxx" --max-attempts=10
 
 You can get this command to run continuously with the --pulling option and you can set the delay between the time the
 message has been set to error and the time the message can be reprocess with --attempt-delay option (in seconds)
 
-    app/console sonata:notification:restart --type="xxx" --type="yyy" --pulling --max-attempts=10 --attempt-delay=60
+    app/console sonata:notification:restart --type="xxx" --pulling --max-attempts=10 --attempt-delay=60


### PR DESCRIPTION
https://github.com/capistrano/capistrano/wiki/Capistrano-Tasks#deploycreate_symlink
