### PR TITLE
Fix doctrine context errors when iterating whith batch queries

### DIFF
--- a/Command/ConsumerHandlerCommand.php
+++ b/Command/ConsumerHandlerCommand.php
@@ -74,7 +74,8 @@ class ConsumerHandlerCommand extends PullingCommand
 
         $startMemoryUsage = memory_get_usage(true);
         $i = 0;
-        foreach ($backend->getIterator() as $message) {
+        $iterator = $backend->getIterator();
+        foreach ($iterator as $message) {
 
             $i++;
             if (!$message->getType()) {
@@ -114,7 +115,9 @@ class ConsumerHandlerCommand extends PullingCommand
                 }
             }
 
-            $this->optimize();
+            if ($iterator->isBufferEmpty()) {
+                $this->optimize();
+            }
 
             if ($input->getOption('iteration') && $i >= (int) $input->getOption('iteration')) {
                 $output->writeln('End of iteration cycle');

--- a/Command/RestartCommand.php
+++ b/Command/RestartCommand.php
@@ -85,7 +85,7 @@ class RestartCommand extends PullingCommand
 
             $output->writeln(sprintf('Reset Message %s <info>#%d</info>, new id %d. Attempt #%d', $message->getType(), $id, $message->getId(), $message->getRestartCount()));
 
-            if ($pullMode) {
+            if ($pullMode && $messages->isBufferEmpty()) {
                 $this->optimize();
             }
         }

--- a/Entity/MessageManager.php
+++ b/Entity/MessageManager.php
@@ -42,11 +42,6 @@ class MessageManager implements MessageManagerInterface
      */
     public function save(MessageInterface $message)
     {
-        //Hack for ConsumerHandlerCommand->optimize()
-        if ($message->getId() && !$this->em->getUnitOfWork()->isInIdentityMap($message)) {
-            $this->em->getUnitOfWork()->merge($message);
-        }
-
         $this->em->persist($message);
         $this->em->flush();
     }

--- a/Iterator/MessageManagerMessageIterator.php
+++ b/Iterator/MessageManagerMessageIterator.php
@@ -85,6 +85,16 @@ class MessageManagerMessageIterator implements MessageIteratorInterface
     }
 
     /**
+     * Return true if the internal buffer is empty
+     *
+     * @return bool
+     */
+    public function isBufferEmpty()
+    {
+        return 0 === count($this->buffer);
+    }
+
+    /**
      * Assign current pointer a message
      */
     protected function setCurrent()


### PR DESCRIPTION
batch messages are duplicated when optimize method cleans the doctrine context
