### PR TITLE
Flush emails when using memory spooling

### DIFF
--- a/Consumer/SwiftMailerConsumer.php
+++ b/Consumer/SwiftMailerConsumer.php
@@ -19,13 +19,15 @@ class SwiftMailerConsumer implements ConsumerInterface
      * @var \Swift_Mailer
      */
     protected $mailer;
+    protected $realTransport;
 
     /**
      * @param $vendorDir
      */
-    public function __construct(\Swift_Mailer $mailer)
+    public function __construct(\Swift_Mailer $mailer, $realTransport = false)
     {
         $this->mailer = $mailer;
+        $this->realTransport = $realTransport;
     }
 
     /**
@@ -42,6 +44,11 @@ class SwiftMailerConsumer implements ConsumerInterface
             $this->sendEmail($event->getMessage());
         } catch (\Exception $e) {
             $exception = $e;
+        }
+
+        $spool = $this->mailer->getTransport()->getSpool();
+        if ($this->realTransport && $spool instanceof \Swift_MemorySpool) {
+            $spool->flushQueue($this->realTransport);
         }
 
         $this->mailer->getTransport()->stop();

--- a/Resources/config/consumer.xml
+++ b/Resources/config/consumer.xml
@@ -13,6 +13,7 @@
         <service id="sonata.notification.consumer.swift_mailer" class="Sonata\NotificationBundle\Consumer\SwiftMailerConsumer">
             <tag name="sonata.notification.consumer" type="mailer" />
             <argument type="service" id="mailer" />
+            <argument type="service" id="swiftmailer.transport.real" />
         </service>
 
         <service id="sonata.notification.consumer.logger" class="Sonata\NotificationBundle\Consumer\LoggerConsumer">


### PR DESCRIPTION
Added flush call when memory spooling is being used.
Changes are based on SwiftmailerBundle's EmailSenderListener.
