### PR TITLE
Fix dependency to easy-extends-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     ],
     "require": {
         "symfony/symfony": ">=2.1,<2.4-dev",
-        "sonata-project/doctrine-extensions": "1.*"
+        "sonata-project/doctrine-extensions": "1.*",
+        "sonata-project/easy-extends-bundle": "2.1.*"
     },
     "suggest": {
         "sonata-project/doctrine-orm-admin-bundle": "2.2.*",


### PR DESCRIPTION
Fix issue #64 "Dependecy with easy-extends-bundle not documented".

I followed the installation documentation and got this error:

```
Generating autoload files
PHP Fatal error:  Class 'Sonata\EasyExtendsBundle\Mapper\DoctrineCollector' not found in 
.../vendor/sonata-project/notification-bundle/Sonata/NotificationBundle/DependencyInjection/SonataNotificationExtension.php on line 293
```
