### PR TITLE
[RuntimeBackend] Appending original exception message to HandlingException message.

### DIFF
--- a/Backend/RuntimeBackend.php
+++ b/Backend/RuntimeBackend.php
@@ -103,7 +103,7 @@ class RuntimeBackend implements BackendInterface
             $message->setCompletedAt(new \DateTime());
             $message->setState(MessageInterface::STATE_ERROR);
 
-            throw new HandlingException("Error while handling a message", 0, $e);
+            throw new HandlingException("Error while handling a message: " . $e->getMessage(), 0, $e);
         }
     }
 


### PR DESCRIPTION
This PR appends the message from the original exception to the HandlingException object created on `RuntimeBackend::handle(MessageInterface $message, EventDispatcherInterface $dispatcher)`. It is useful for debugging purposes, i.e. on phpunit or codeception outputs when an exception is thrown.
