### PR TITLE
Fix restart notification

### DIFF
--- a/Entity/BaseMessage.php
+++ b/Entity/BaseMessage.php
@@ -29,4 +29,10 @@ class BaseMessage extends Message
     {
         return $this->id;
     }
+
+    public function __clone()
+    {
+        parent::__clone();
+        $this->id = null;
+    }
 }

--- a/Entity/MessageManager.php
+++ b/Entity/MessageManager.php
@@ -208,7 +208,8 @@ class MessageManager implements MessageManagerInterface
             return;
         }
 
-        $this->cancel($message);
+        $message->setState(MessageInterface::STATE_CANCELLED);
+        $this->save($message);
 
         $count = $message->getRestartCount();
 


### PR DESCRIPTION
Fix for:
- Cloned message isn't saved as new, because `id` property has original value.
- Original message wasn't canceled, because `cancel` method doesn't cancel messages with error state.
