### PR TITLE
Add enabled key in admin config

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -86,6 +86,7 @@ class Configuration implements ConfigurationInterface
             ->arrayNode('admin')
                 ->addDefaultsIfNotSet()
                 ->children()
+                    ->booleanNode('enabled')->defaultTrue()->end()
                     ->arrayNode('message')
                         ->addDefaultsIfNotSet()
                         ->children()

--- a/DependencyInjection/SonataNotificationExtension.php
+++ b/DependencyInjection/SonataNotificationExtension.php
@@ -53,7 +53,7 @@ class SonataNotificationExtension extends Extension
             $loader->load('api_controllers.xml');
         }
 
-        if (isset($bundles['SonataDoctrineORMAdminBundle'])) { // for now, only support for ORM
+        if ($config['admin']['enabled'] && isset($bundles['SonataDoctrineORMAdminBundle'])) { // for now, only support for ORM
             $loader->load('admin.xml');
         }
 

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -62,6 +62,15 @@ Backend availables :
     sonata_notification:
         backend: sonata.notification.backend.runtime
 
+You can disable the admin if you don't need it :
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+    sonata_notification:
+        admin:
+            enabled: false
+
 Extending the Bundle
 --------------------
 At this point, the bundle is functional, but not quite ready yet. You need to


### PR DESCRIPTION
Allows to disable the notification admin if not used. Enabled by default.
