### PR TITLE
Fix an obvious typo

### DIFF
--- a/Entity/MessageManager.php
+++ b/Entity/MessageManager.php
@@ -23,7 +23,7 @@ class MessageManager extends BaseEntityManager implements MessageManagerInterfac
     public function save($message, $andFlush = true)
     {
         //Hack for ConsumerHandlerCommand->optimize()
-        if ($message->getId() && !$this->om->getUnitOfWork()->isInIdentityMap($message)) {
+        if ($message->getId() && !$this->em->getUnitOfWork()->isInIdentityMap($message)) {
             $this->getEntityManager()->getUnitOfWork()->merge($message);
         }
 


### PR DESCRIPTION
Fixed a typo in a reference to the entity manager which caused the following error when running the `sonata:notification:start` command.
