### PR TITLE
Add a command to create and publish notifications

### DIFF
--- a/Command/CreateAndPublishCommand.php
+++ b/Command/CreateAndPublishCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NotificationBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CreateAndPublishCommand extends ContainerAwareCommand
+{
+    public function configure()
+    {
+        $this
+            ->setName('sonata:notification:create-and-publish')
+            ->addArgument('type', InputArgument::REQUIRED, 'Type of the notification')
+            ->addArgument('body', InputArgument::REQUIRED, 'Body of the notification (json)');
+        ;
+    }
+
+    /**
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     *
+     * @return void
+     */
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $type = $input->getArgument('type');
+        $body = json_decode($input->getArgument('body'), true);
+
+        if (null === $body) {
+            throw new \InvalidArgumentException('Body does not contain valid json.');
+        }
+
+        $this->getContainer()
+            ->get('sonata.notification.backend')
+            ->createAndPublish($type, $body)
+        ;
+
+        $output->writeln('<info>Done !</info>');
+    }
+}

--- a/Resources/doc/reference/command_line.rst
+++ b/Resources/doc/reference/command_line.rst
@@ -70,3 +70,10 @@ message has been set to error and the time the message can be reprocess with --a
 .. code-block:: bash
 
     app/console sonata:notification:restart --type="xxx" --pulling --max-attempts=10 --attempt-delay=60 --pause=500000 --batch-size=10
+
+Create and publish messages
+---------------------------
+
+For testing purpose, you might want to manually create and publish messages::
+
+    app/console sonata:notification:create-and-publish logger '{"level":"debug","message":"Hello world!"}'


### PR DESCRIPTION
I needed this command to do some tests, I thought it would be usefull if it was in the bundle ! Example : 

`app/console sonata:notification:create-and-publish logger '{"level":"debug","message":"Hello world!"}'`
