### PR TITLE
Changed conflicting index name

### DIFF
--- a/Resources/config/doctrine/BaseMessage.orm.xml
+++ b/Resources/config/doctrine/BaseMessage.orm.xml
@@ -13,7 +13,7 @@
         <field name="completedAt"  type="datetime"   column="completed_at" nullable="true" />
 
         <indexes>
-            <index name="state" columns="state" />
+            <index name="notification_message_state_idx" columns="state" />
             <index name="createdAt" columns="created_at" />
         </indexes>
     </mapped-superclass>


### PR DESCRIPTION
I had a conflict with duplicate index creation by using the NotificationBundle and the PaymentBundle. Both wanted to create an index with name 'state'.
So I changed the index name to a less generic one.