### PR TITLE
Improved support for symfony 3

### DIFF
--- a/Controller/Api/MessageController.php
+++ b/Controller/Api/MessageController.php
@@ -127,7 +127,7 @@ class MessageController
             'csrf_protection' => false,
         ));
 
-        $form->bind($request);
+        $form->handleRequest($request);
 
         if ($form->isValid()) {
             $message = $form->getData();

--- a/Tests/Backend/MessageManagerBackendTest.php
+++ b/Tests/Backend/MessageManagerBackendTest.php
@@ -107,7 +107,7 @@ class MessageManagerBackendTest extends \PHPUnit_Framework_TestCase
     public static function statusProvider()
     {
         if (!class_exists('ZendDiagnostics\Result\Success')) {
-            return array(array(1,1,1));
+            return array(array(1, 1, 1));
         }
 
         $data = array();

--- a/Tests/Consumer/LoggerConsumerTest.php
+++ b/Tests/Consumer/LoggerConsumerTest.php
@@ -17,14 +17,20 @@ use Sonata\NotificationBundle\Tests\Entity\Message;
 
 class LoggerConsumerTest extends \PHPUnit_Framework_TestCase
 {
-    public function testProcess()
+    /**
+     * @dataProvider calledTypeProvider
+     *
+     * @param $type
+     * @param $calledType
+     */
+    public function testProcess($type, $calledType)
     {
-        $logger = $this->getMock('Symfony\Component\HttpKernel\Log\LoggerInterface');
-        $logger->expects($this->once())->method('crit');
+        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger->expects($this->once())->method($calledType);
 
         $message = new Message();
         $message->setBody(array(
-            'level'   => 'crit',
+            'level'   => $type,
             'message' => 'Alert - Area 52 get compromised!!',
         ));
 
@@ -35,11 +41,28 @@ class LoggerConsumerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @return array[]
+     */
+    public function calledTypeProvider()
+    {
+        return array(
+            array('emerg', 'emergency'),
+            array('alert', 'alert'),
+            array('crit', 'critical'),
+            array('err', 'error'),
+            array('warn', 'warning'),
+            array('notice', 'notice'),
+            array('info', 'info'),
+            array('debug', 'debug'),
+        );
+    }
+
+    /**
      * @expectedException \Sonata\NotificationBundle\Exception\InvalidParameterException
      */
     public function testInvalidType()
     {
-        $logger = $this->getMock('Symfony\Component\HttpKernel\Log\LoggerInterface');
+        $logger = $this->getMock('Psr\Log\LoggerInterface');
 
         $message = new Message();
         $message->setBody(array(

--- a/Tests/Controller/Api/MessageControllerTest.php
+++ b/Tests/Controller/Api/MessageControllerTest.php
@@ -42,7 +42,7 @@ class MessageControllerTest extends \PHPUnit_Framework_TestCase
         $messageManager->expects($this->once())->method('save')->will($this->returnValue($message));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
-        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($message));
 
@@ -62,7 +62,7 @@ class MessageControllerTest extends \PHPUnit_Framework_TestCase
         $messageManager->expects($this->never())->method('save')->will($this->returnValue($message));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
-        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
         $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');


### PR DESCRIPTION
- ``LoggerInterface`` dropped some methods (deprecated since 2.2)
- the ``bind`` method is replaced with ``handleRequest`` in ``FormInterface`` (deprecated since symfony 2.2)