### PR TITLE
added Style CI bridge to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         "swiftmailer/swiftmailer": "^4.3 || ^5.0",
         "friendsofsymfony/rest-bundle": "^1.1",
         "jms/serializer-bundle": "^0.13 || ^1.0",
-        "nelmio/api-doc-bundle": "^2.4"
+        "nelmio/api-doc-bundle": "^2.4",
+        "sllh/php-cs-fixer-styleci-bridge": "^2.0"
     },
     "conflict": {
         "jms/serializer": "<0.13"


### PR DESCRIPTION
### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Added
- Added `sllh/php-cs-fixer-styleci-bridge` as dependency for dev
```

### Subject

An error occured:
```
PHP Warning:  Uncaught exception 'ErrorException' with message 'require_once(/project/vendor/sllh/php-cs-fixer-styleci-bridge/autoload.php): failed to open stream: No such file or directory' in /project/.php_cs:11
Stack trace:
#0 /project/.php_cs(11): {closure}(2, 'require_once(/p...', '/project/.php_c...', 11, Array)
#1 /project/.php_cs(11): require_once()
#2 /root/.composer/vendor/fabpot/php-cs-fixer/Symfony/CS/Console/Command/FixCommand.php(318): include('/project/.php_c...')
```