### PR TITLE
Use AbstractAdmin instead of deprecated Admin class

### DIFF
--- a/Admin/MessageAdmin.php
+++ b/Admin/MessageAdmin.php
@@ -11,13 +11,13 @@
 
 namespace Sonata\NotificationBundle\Admin;
 
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\AdminBundle\Show\ShowMapper;
 
-class MessageAdmin extends Admin
+class MessageAdmin extends AbstractAdmin
 {
     /**
      * {@inheritdoc}

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "zendframework/zenddiagnostics": "^1.0"
     },
     "suggest": {
+        "sonata-project/admin-bundle": "To be able to use MessageAdmin.",
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
         "guzzle/guzzle" : "^3.9",
         "liip/monitor-bundle": "^1.0",
@@ -51,7 +52,8 @@
         "sllh/php-cs-fixer-styleci-bridge": "^2.0"
     },
     "conflict": {
-        "jms/serializer": "<0.13"
+        "jms/serializer": "<0.13",
+        "sonata-project/admin-bundle": "<3.1"
     },
     "autoload": {
         "psr-4": { "Sonata\\NotificationBundle\\": "" }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a fix.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix deprecated usage of `Admin` class
```

## Subject

The **Admin** class is deprecated since SonataAdminBundle 3.1

