### PR TITLE
Update vendor videlalvaro/php-amqplib to php-amqplib/php-amqplib

### DIFF
--- a/Backend/AMQPBackend.php
+++ b/Backend/AMQPBackend.php
@@ -73,7 +73,7 @@ class AMQPBackend implements BackendInterface
         $this->deadLetterExchange = $deadLetterExchange;
 
         if (!class_exists('PhpAmqpLib\Message\AMQPMessage')) {
-            throw new \RuntimeException('Please install videlalvaro/php-amqplib dependency');
+            throw new \RuntimeException('Please install php-amqplib/php-amqplib dependency');
         }
     }
 

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -6,7 +6,7 @@ To begin, add the dependent bundles:
 .. code-block:: bash
 
     php composer.phar require sonata-project/notification-bundle
-    php composer.phar require videlalvaro/php-amqplib --no-update # optional
+    php composer.phar require php-amqplib/php-amqplib --no-update # optional
     php composer.phar require liip/monitor-bundle --no-update     # optional
     php composer.phar require friendsofsymfony/rest-bundle  --no-update # optional when using api
     php composer.phar require nelmio/api-doc-bundle  --no-update # optional when using api

--- a/composer.json
+++ b/composer.json
@@ -37,12 +37,12 @@
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
         "guzzle/guzzle" : "^3.9",
         "liip/monitor-bundle": "^1.0",
-        "videlalvaro/php-amqplib": "^2.0"
+        "php-amqplib/php-amqplib": "^2.0"
     },
     "require-dev": {
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
         "guzzle/guzzle" : "^3.8",
-        "videlalvaro/php-amqplib": "^2.0",
+        "php-amqplib/php-amqplib": "^2.0",
         "liip/monitor-bundle": "^2.0",
         "symfony/phpunit-bridge": "^2.7 || ^3.0",
         "swiftmailer/swiftmailer": "^4.3 || ^5.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this affects all version of the bundle, it does not introduce a BC-break as it is the same library just under a new name and maintainer.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Changes the name of the vendor videlalvaro/php-amqplib to its new name php-amqplib/php-amqplib
```



## Update vendor videlalvaro/php-amqplib to php-amqplib/php-amqplib

<!-- Describe your Pull Request content here -->

The  videlalvaro/php-amqplib is abandoned and is now php-amqplib/php-amqplib.
Check packagist: https://packagist.org/packages/videlalvaro/php-amqplib