### PR TITLE
Add CC and BCC function in sendEmail

### DIFF
--- a/Consumer/SwiftMailerConsumer.php
+++ b/Consumer/SwiftMailerConsumer.php
@@ -76,7 +76,7 @@ class SwiftMailerConsumer implements ConsumerInterface
         if ($html = $message->getValue(array('message', 'html'))) {
             $mail->addPart($html, 'text/html');
         }
-        
+
         $this->mailer->send($mail);
     }
 }

--- a/Consumer/SwiftMailerConsumer.php
+++ b/Consumer/SwiftMailerConsumer.php
@@ -64,7 +64,15 @@ class SwiftMailerConsumer implements ConsumerInterface
         if ($replyTo = $message->getValue('replyTo')) {
             $mail->setReplyTo($replyTo);
         }
-
+        
+        if ($ccTo = $message->getValue('cc')) {
+            $mail->setCc($ccTo);
+        }
+        
+        if ($bccTo = $message->getValue('bcc')) {
+            $mail->setBcc($bccTo);
+        }
+        
         if ($text = $message->getValue(array('message', 'text'))) {
             $mail->addPart($text, 'text/plain');
         }

--- a/Consumer/SwiftMailerConsumer.php
+++ b/Consumer/SwiftMailerConsumer.php
@@ -76,6 +76,7 @@ class SwiftMailerConsumer implements ConsumerInterface
         if ($html = $message->getValue(array('message', 'html'))) {
             $mail->addPart($html, 'text/html');
         }
+        
         $this->mailer->send($mail);
     }
 }

--- a/Consumer/SwiftMailerConsumer.php
+++ b/Consumer/SwiftMailerConsumer.php
@@ -64,23 +64,18 @@ class SwiftMailerConsumer implements ConsumerInterface
         if ($replyTo = $message->getValue('replyTo')) {
             $mail->setReplyTo($replyTo);
         }
-        
         if ($ccTo = $message->getValue('cc')) {
             $mail->setCc($ccTo);
         }
-        
         if ($bccTo = $message->getValue('bcc')) {
             $mail->setBcc($bccTo);
         }
-        
         if ($text = $message->getValue(array('message', 'text'))) {
             $mail->addPart($text, 'text/plain');
         }
-
         if ($html = $message->getValue(array('message', 'html'))) {
             $mail->addPart($html, 'text/html');
         }
-
         $this->mailer->send($mail);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

Changes  in sendEmail function CC and BCC parameters added

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Added
- CC and BCC function added
```

```
if ($ccTo = $message->getValue('cc')) {
    $mail->setCc($ccTo);
}
if ($bccTo = $message->getValue('bcc')) {
    $mail->setBcc($bccTo);
}
```
## Subject

Add CC and BCC parameters in sendEmail function
