### PR TITLE
Fixed duplicate translation in batch actions

### DIFF
--- a/Admin/MessageAdmin.php
+++ b/Admin/MessageAdmin.php
@@ -38,12 +38,14 @@ class MessageAdmin extends AbstractAdmin
     {
         $actions = array();
         $actions['publish'] = array(
-            'label' => $this->trans($this->getLabelTranslatorStrategy()->getLabel('publish', 'batch', 'message')),
+            'label' => $this->getLabelTranslatorStrategy()->getLabel('publish', 'batch', 'message'),
+            'translation_domain' => $this->getTranslationDomain(),
             'ask_confirmation' => false,
         );
 
         $actions['cancelled'] = array(
-            'label' => $this->trans($this->getLabelTranslatorStrategy()->getLabel('cancelled', 'batch', 'message')),
+            'label' => $this->getLabelTranslatorStrategy()->getLabel('cancelled', 'batch', 'message'),
+            'translation_domain' => $this->getTranslationDomain(),
             'ask_confirmation' => false,
         );
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a BC fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Fixed duplicate translation of batch actions
```

## Subject

The translation of the batch actions is done in the template since the 3.0 release of the admin bundle.
