### PR TITLE
use guzzlehttp/guzzle instead of deprecated guzzle/guzzle

### DIFF
--- a/Backend/AMQPBackendDispatcher.php
+++ b/Backend/AMQPBackendDispatcher.php
@@ -115,7 +115,9 @@ class AMQPBackendDispatcher extends QueueBackendDispatcher
      */
     public function getIterator()
     {
-        throw new \RuntimeException('You need to use a specific rabbitmq backend supporting the selected queue to run a consumer.');
+        throw new \RuntimeException(
+            'You need to use a specific rabbitmq backend supporting the selected queue to run a consumer.'
+        );
     }
 
     /**
@@ -123,7 +125,9 @@ class AMQPBackendDispatcher extends QueueBackendDispatcher
      */
     public function handle(MessageInterface $message, EventDispatcherInterface $dispatcher)
     {
-        throw new \RuntimeException('You need to use a specific rabbitmq backend supporting the selected queue to run a consumer.');
+        throw new \RuntimeException(
+            'You need to use a specific rabbitmq backend supporting the selected queue to run a consumer.'
+        );
     }
 
     /**
@@ -149,11 +153,16 @@ class AMQPBackendDispatcher extends QueueBackendDispatcher
             }
 
             if ($checked !== count($this->queues)) {
-                return new Failure('Not all queues for the available notification types registered in the rabbitmq broker. Are the consumer commands running?');
+                return new Failure(
+                    'Not all queues for the available notification types registered in the rabbitmq broker. '
+                    .'Are the consumer commands running?'
+                );
             }
 
             if (count($missingConsumers) > 0) {
-                return new Failure('There are no rabbitmq consumers running for the queues: '.implode(', ', $missingConsumers));
+                return new Failure(
+                    'There are no rabbitmq consumers running for the queues: '.implode(', ', $missingConsumers)
+                );
             }
         } catch (\Exception $e) {
             return new Failure($e->getMessage());
@@ -167,7 +176,9 @@ class AMQPBackendDispatcher extends QueueBackendDispatcher
      */
     public function cleanup()
     {
-        throw new \RuntimeException('You need to use a specific rabbitmq backend supporting the selected queue to run a consumer.');
+        throw new \RuntimeException(
+            'You need to use a specific rabbitmq backend supporting the selected queue to run a consumer.'
+        );
     }
 
     public function shutdown()
@@ -198,7 +209,10 @@ class AMQPBackendDispatcher extends QueueBackendDispatcher
     protected function getApiQueueStatus()
     {
         if (class_exists('Guzzle\Http\Client') === false) {
-            throw new \RuntimeException('The guzzle http client library is required to run rabbitmq health checks. Make sure to add guzzle/guzzle to your composer.json.');
+            throw new \RuntimeException(
+                'The guzzle http client library is required to run rabbitmq health checks. '
+                .'Make sure to add guzzlehttp/guzzle to your composer.json.'
+            );
         }
 
         $client = new \Guzzle\Http\Client();

--- a/Backend/AMQPBackendDispatcher.php
+++ b/Backend/AMQPBackendDispatcher.php
@@ -53,7 +53,7 @@ class AMQPBackendDispatcher extends QueueBackendDispatcher
     }
 
     /**
-     * @return AMQPChannelannel
+     * @return AMQPChannel
      */
     public function getChannel()
     {

--- a/composer.json
+++ b/composer.json
@@ -35,13 +35,13 @@
     "suggest": {
         "sonata-project/admin-bundle": "To be able to use MessageAdmin.",
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
-        "guzzle/guzzle" : "^3.9",
+        "guzzlehttp/guzzle" : "If you want to get a status report when using the rabbitMQ backend.",
         "liip/monitor-bundle": "^1.0",
         "php-amqplib/php-amqplib": "^2.0"
     },
     "require-dev": {
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
-        "guzzle/guzzle" : "^3.8",
+        "guzzlehttp/guzzle" : "^3.8",
         "php-amqplib/php-amqplib": "^2.0",
         "liip/monitor-bundle": "^2.0",
         "symfony/phpunit-bridge": "^2.7 || ^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a BC change.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- dependency from `guzzle/guzzle` to `guzzlehttp/guzzle`, because it is deprecated
```

## Subject

Package guzzle/guzzle is abandoned, you should avoid using it. Use guzzlehttp/guzzle instead.

Old one: https://packagist.org/packages/guzzle/guzzle
New one: https://packagist.org/packages/guzzlehttp/guzzle