### PR TITLE
Added dead letter handling in AMQPBackend

### DIFF
--- a/Backend/AMQPBackendDispatcher.php
+++ b/Backend/AMQPBackendDispatcher.php
@@ -81,7 +81,7 @@ class AMQPBackendDispatcher extends QueueBackendDispatcher
      */
     public function getBackend($type)
     {
-        if (false === $this->backendsInitialized) {
+        if (!$this->backendsInitialized) {
             foreach ($this->backends as $backend) {
                 $backend['backend']->initialize();
             }

--- a/Backend/AMQPBackendDispatcher.php
+++ b/Backend/AMQPBackendDispatcher.php
@@ -39,6 +39,8 @@ class AMQPBackendDispatcher extends QueueBackendDispatcher
      */
     protected $connection;
 
+    protected $backendsInitialized = false;
+
     /**
      * @param array  $settings
      * @param array  $queues
@@ -79,6 +81,13 @@ class AMQPBackendDispatcher extends QueueBackendDispatcher
      */
     public function getBackend($type)
     {
+        if (false === $this->backendsInitialized) {
+            foreach ($this->backends as $backend) {
+                $backend['backend']->initialize();
+            }
+            $this->backendsInitialized = true;
+        }
+
         $default = null;
 
         if (count($this->queues) === 0) {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -213,6 +213,15 @@ Only used by RabbitMQ
 If is set, failed messages will be rejected and sent to this exchange
 EOF;
 
+        $deadLetterRoutingKey = <<<'EOF'
+Only used by RabbitMQ
+
+If is set, failed messages will be routed to the queue using this key by dead-letter-exchange,
+otherwise it will be requeued to the original queue if `dead-letter-exchange` is set
+
+If is set, the queue must be configured with this key as routing_key
+EOF;
+
         $typesInfo = <<<'EOF'
 Only used by Doctrine
 
@@ -248,6 +257,10 @@ EOF;
                 ->end()
                 ->scalarNode('dead_letter_exchange')
                     ->info($deadLetterExchangeInfo)
+                    ->defaultValue(null)
+                ->end()
+                ->scalarNode('dead_letter_routing_key')
+                    ->info($deadLetterRoutingKey)
                     ->defaultValue(null)
                 ->end()
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -216,10 +216,10 @@ EOF;
         $deadLetterRoutingKey = <<<'EOF'
 Only used by RabbitMQ
 
-If is set, failed messages will be routed to the queue using this key by dead-letter-exchange,
-otherwise it will be requeued to the original queue if `dead-letter-exchange` is set
+If set, failed messages will be routed to the queue using this key by dead-letter-exchange,
+otherwise it will be requeued to the original queue if `dead-letter-exchange` is set.
 
-If is set, the queue must be configured with this key as routing_key
+If set, the queue must be configured with this key as `routing_key`.
 EOF;
 
         $typesInfo = <<<'EOF'

--- a/DependencyInjection/SonataNotificationExtension.php
+++ b/DependencyInjection/SonataNotificationExtension.php
@@ -335,9 +335,12 @@ class SonataNotificationExtension extends Extension
 
         $deadLetterRoutingKeys = $this->getQueuesParameters('dead_letter_routing_key', $queues);
         $routingKeys = $this->getQueuesParameters('routing_key', $queues);
+
         foreach ($deadLetterRoutingKeys as $key) {
             if (!in_array($key, $routingKeys)) {
-                throw new \RuntimeException(sprintf('You must configure the queue having the routing_key "%s" same as dead_letter_routing_key', $key));
+                throw new \RuntimeException(sprintf(
+                    'You must configure the queue having the routing_key "%s" same as dead_letter_routing_key', $key
+                ));
             }
         }
 
@@ -353,7 +356,9 @@ class SonataNotificationExtension extends Extension
 
             if ($queue['dead_letter_routing_key']) {
                 if (is_null($queue['dead_letter_exchange'])) {
-                    throw new \RuntimeException('dead_letter_exchange must be configured when dead_letter_routing_key is set');
+                    throw new \RuntimeException(
+                        'dead_letter_exchange must be configured when dead_letter_routing_key is set'
+                    );
                 }
             }
 
@@ -363,7 +368,15 @@ class SonataNotificationExtension extends Extension
                 $exchange = $baseExchange;
             }
 
-            $id = $this->createAMQPBackend($container, $exchange, $queue['queue'], $queue['recover'], $queue['routing_key'], $queue['dead_letter_exchange'], $queue['dead_letter_routing_key']);
+            $id = $this->createAMQPBackend(
+                $container,
+                $exchange,
+                $queue['queue'],
+                $queue['recover'],
+                $queue['routing_key'],
+                $queue['dead_letter_exchange'],
+                $queue['dead_letter_routing_key']
+            );
 
             $amqBackends[$pos] = array(
                 'type' => $queue['routing_key'],
@@ -406,7 +419,17 @@ class SonataNotificationExtension extends Extension
     {
         $id = 'sonata.notification.backend.rabbitmq.'.$this->amqpCounter++;
 
-        $definition = new Definition('Sonata\NotificationBundle\Backend\AMQPBackend', array($exchange, $name, $recover, $key, $deadLetterExchange, $deadLetterRoutingKey));
+        $definition = new Definition(
+            'Sonata\NotificationBundle\Backend\AMQPBackend',
+            array(
+                $exchange,
+                $name,
+                $recover,
+                $key,
+                $deadLetterExchange,
+                $deadLetterRoutingKey,
+            )
+        );
         $definition->setPublic(false);
         $container->setDefinition($id, $definition);
 

--- a/DependencyInjection/SonataNotificationExtension.php
+++ b/DependencyInjection/SonataNotificationExtension.php
@@ -319,7 +319,7 @@ class SonataNotificationExtension extends Extension
     {
         $queues = $config['queues'];
         $connection = $config['backends']['rabbitmq']['connection'];
-        $exchange = $config['backends']['rabbitmq']['exchange'];
+        $baseExchange = $config['backends']['rabbitmq']['exchange'];
         $amqBackends = array();
 
         if (count($queues) == 0) {
@@ -329,7 +329,16 @@ class SonataNotificationExtension extends Extension
                 'routing_key' => '',
                 'recover' => false,
                 'dead_letter_exchange' => null,
+                'dead_letter_routing_key' => null,
             ));
+        }
+
+        $deadLetterRoutingKeys = $this->getQueuesParameters('dead_letter_routing_key', $queues);
+        $routingKeys = $this->getQueuesParameters('routing_key', $queues);
+        foreach ($deadLetterRoutingKeys as $key) {
+            if (!in_array($key, $routingKeys)) {
+                throw new \RuntimeException(sprintf('You must configure the queue having the routing_key "%s" same as dead_letter_routing_key', $key));
+            }
         }
 
         $declaredQueues = array();
@@ -342,7 +351,19 @@ class SonataNotificationExtension extends Extension
 
             $declaredQueues[] = $queue['queue'];
 
-            $id = $this->createAMQPBackend($container, $exchange, $queue['queue'], $queue['recover'], $queue['routing_key'], $queue['dead_letter_exchange']);
+            if ($queue['dead_letter_routing_key']) {
+                if (is_null($queue['dead_letter_exchange'])) {
+                    throw new \RuntimeException('dead_letter_exchange must be configured when dead_letter_routing_key is set');
+                }
+            }
+
+            if (in_array($queue['routing_key'], $deadLetterRoutingKeys)) {
+                $exchange = $this->getAMQPDeadLetterExchangeByRoutingKey($queue['routing_key'], $queues);
+            } else {
+                $exchange = $baseExchange;
+            }
+
+            $id = $this->createAMQPBackend($container, $exchange, $queue['queue'], $queue['recover'], $queue['routing_key'], $queue['dead_letter_exchange'], $queue['dead_letter_routing_key']);
 
             $amqBackends[$pos] = array(
                 'type' => $queue['routing_key'],
@@ -377,17 +398,53 @@ class SonataNotificationExtension extends Extension
      * @param string           $recover
      * @param string           $key
      * @param string           $deadLetterExchange
+     * @param string           $deadLetterRoutingKey
      *
      * @return string
      */
-    protected function createAMQPBackend(ContainerBuilder $container, $exchange, $name, $recover, $key = '', $deadLetterExchange = null)
+    protected function createAMQPBackend(ContainerBuilder $container, $exchange, $name, $recover, $key = '', $deadLetterExchange = null, $deadLetterRoutingKey = null)
     {
         $id = 'sonata.notification.backend.rabbitmq.'.$this->amqpCounter++;
 
-        $definition = new Definition('Sonata\NotificationBundle\Backend\AMQPBackend', array($exchange, $name, $recover, $key, $deadLetterExchange));
+        $definition = new Definition('Sonata\NotificationBundle\Backend\AMQPBackend', array($exchange, $name, $recover, $key, $deadLetterExchange, $deadLetterRoutingKey));
         $definition->setPublic(false);
         $container->setDefinition($id, $definition);
 
         return $id;
+    }
+
+    /**
+     * @param string $name
+     * @param array  $queues
+     *
+     * @return string[]
+     */
+    private function getQueuesParameters($name, array $queues)
+    {
+        $params = array_unique(array_map(function ($q) use ($name) {
+            return $q[$name];
+        }, $queues));
+
+        $idx = array_search(null, $params);
+        if ($idx !== false) {
+            unset($params[$idx]);
+        }
+
+        return $params;
+    }
+
+    /**
+     * @param string $key
+     * @param array  $queues
+     *
+     * @return string
+     */
+    private function getAMQPDeadLetterExchangeByRoutingKey($key, array $queues)
+    {
+        foreach ($queues as $queue) {
+            if ($queue['dead_letter_routing_key'] === $key) {
+                return $queue['dead_letter_exchange'];
+            }
+        }
     }
 }

--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -48,14 +48,6 @@ Full configuration options:
                 # If is set, failed messages will be rejected and sent to this exchange
                 dead_letter_exchange:  null
 
-                # Only used by RabbitMQ
-                #
-                # If is set, failed messages will be routed to the queue using this key by dead-letter-exchange,
-                # otherwise it will be requeued to the original queue if `dead-letter-exchange` is set
-                #
-                # If is set, the queue must be configured with this key as routing_key
-                dead_letter_routing_key:  null
-
                 # Only used by Doctrine
                 #
                 # Defines types handled by the message backend

--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -48,6 +48,14 @@ Full configuration options:
                 # If is set, failed messages will be rejected and sent to this exchange
                 dead_letter_exchange:  null
 
+                # Only used by RabbitMQ
+                #
+                # If is set, failed messages will be routed to the queue using this key by dead-letter-exchange,
+                # otherwise it will be requeued to the original queue if `dead-letter-exchange` is set
+                #
+                # If is set, the queue must be configured with this key as routing_key
+                dead_letter_routing_key:  null
+
                 # Only used by Doctrine
                 #
                 # Defines types handled by the message backend

--- a/Tests/Backend/AMQPBackendDispatcherTest.php
+++ b/Tests/Backend/AMQPBackendDispatcherTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NotificationBundle\Tests\Backend;
+
+use Sonata\NotificationBundle\Backend\AMQPBackendDispatcher;
+
+class AMQPBackendDispatcherTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        if (!class_exists('PhpAmqpLib\Message\AMQPMessage')) {
+            $this->markTestSkipped('AMQP Lib not installed');
+        }
+    }
+
+    public function testQueue()
+    {
+        $mock = $this->getMockQueue('foo', 'message.type.foo', $this->once());
+        $mock2 = $this->getMockQueue('bar', 'message.type.foo', $this->never());
+        $fooBackend = array('type' => 'message.type.foo', 'backend' => $mock);
+        $barBackend = array('type' => 'message.type.bar', 'backend' => $mock2);
+        $backends = array($fooBackend, $barBackend);
+        $dispatcher = $this->getDispatcher($backends);
+        $dispatcher->createAndPublish('message.type.foo', array());
+    }
+
+    public function testDefaultQueue()
+    {
+        $mock = $this->getMockQueue('foo', 'message.type.foo', $this->once());
+        $fooBackend = array('type' => 'default', 'backend' => $mock);
+        $dispatcher = $this->getDispatcher(array($fooBackend));
+        $dispatcher->createAndPublish('some.other.type', array());
+    }
+
+    /**
+     * @expectedException \Sonata\NotificationBundle\Exception\BackendNotFoundException
+     */
+    public function testDefaultQueueNotFound()
+    {
+        $mock = $this->getMockQueue('foo', 'message.type.foo', $this->never());
+        $fooBackend = array('type' => 'message.type.foo', 'backend' => $mock);
+        $dispatcher = $this->getDispatcher(array($fooBackend));
+        $dispatcher->createAndPublish('some.other.type', array());
+    }
+
+    /**
+     * @expectedException \Sonata\NotificationBundle\Exception\BackendNotFoundException
+     */
+    public function testInvalidQueue()
+    {
+        $mock = $this->getMockQueue('foo', 'message.type.bar');
+        $dispatcher = $this->getDispatcher(
+            array(array('type' => 'bar', 'backend' => $mock)),
+            array(array('queue' => 'foo', 'routing_key' => 'message.type.bar'))
+        );
+        $dispatcher->createAndPublish('message.type.bar', array());
+    }
+
+    public function testAllQueueInitializeOnce()
+    {
+        $queues = array(
+            array('queue' => 'foo', 'routing_key' => 'message.type.foo'),
+            array('queue' => 'bar', 'routing_key' => 'message.type.bar'),
+            array('queue' => 'baz', 'routing_key' => 'message.type.baz'),
+        );
+        $backends = array();
+        foreach ($queues as $queue) {
+            $mock = $this->getMockQueue($queue['queue'], $queue['routing_key']);
+            $mock->expects($this->once())
+                ->method('initialize');
+            $backends[] = array('type' => $queue['routing_key'], 'backend' => $mock);
+        }
+        $dispatcher = $this->getDispatcher($backends, $queues);
+        $dispatcher->createAndPublish('message.type.foo', array());
+        $dispatcher->createAndPublish('message.type.foo', array());
+    }
+
+    protected function getMockQueue($queue, $type, $called = null)
+    {
+        $methods = array('createAndPublish', 'initialize');
+        $args = array('', 'foo', false, 'message.type.foo');
+        $mock = $this->getMockBuilder('Sonata\NotificationBundle\Backend\AMQPBackend')
+                     ->setConstructorArgs($args)
+                     ->setMethods($methods)
+                     ->getMock();
+
+        if ($called !== null) {
+            $mock->expects($called)
+                ->method('createAndPublish')
+            ;
+        }
+
+        return $mock;
+    }
+
+    protected function getDispatcher(array $backends, array $queues = array(array('queue' => 'foo', 'routing_key' => 'message.type.foo')))
+    {
+        $settings = array(
+                'host' => 'foo',
+                'port' => 'port',
+                'user' => 'user',
+                'pass' => 'pass',
+                'vhost' => '/',
+        );
+
+        return new AMQPBackendDispatcher($settings, $queues, 'default', $backends);
+    }
+}

--- a/Tests/Backend/AMQPBackendTest.php
+++ b/Tests/Backend/AMQPBackendTest.php
@@ -19,7 +19,7 @@ class AMQPBackendTest extends \PHPUnit_Framework_TestCase
     const DEAD_LETTER_EXCHANGE = 'dlx';
     const DEAD_LETTER_ROUTING_KEY = 'message.type.dl';
 
-    public function setUp()
+    protected function setUp()
     {
         if (!class_exists('PhpAmqpLib\Channel\AMQPChannel')) {
             $this->markTestSkipped('AMQP Lib not installed');
@@ -67,6 +67,13 @@ class AMQPBackendTest extends \PHPUnit_Framework_TestCase
             ->withConsecutive(
                 array(
                     $this->equalTo(self::EXCHANGE),
+                    $this->equalTo('direct'),
+                    $this->isType('boolean'),
+                    $this->isType('boolean'),
+                    $this->isType('boolean'),
+                ),
+                array(
+                    $this->equalTo(self::DEAD_LETTER_EXCHANGE),
                     $this->equalTo('direct'),
                     $this->isType('boolean'),
                     $this->isType('boolean'),

--- a/Tests/Backend/AMQPBackendTest.php
+++ b/Tests/Backend/AMQPBackendTest.php
@@ -9,85 +9,170 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\NotificationBundle\Tests\Notification;
-
-use Sonata\NotificationBundle\Backend\AMQPBackendDispatcher;
+namespace Sonata\NotificationBundle\Tests\Backend;
 
 class AMQPBackendTest extends \PHPUnit_Framework_TestCase
 {
+    const EXCHANGE = 'exchange';
+    const QUEUE = 'foo';
+    const KEY = 'message.type.foo';
+    const DEAD_LETTER_EXCHANGE = 'dlx';
+    const DEAD_LETTER_ROUTING_KEY = 'message.type.dl';
+
     public function setUp()
     {
-        if (!class_exists('PhpAmqpLib\Message\AMQPMessage')) {
+        if (!class_exists('PhpAmqpLib\Channel\AMQPChannel')) {
             $this->markTestSkipped('AMQP Lib not installed');
         }
     }
 
-    public function testQueue()
+    public function testInitializeWithNoDeadLetterExchangeAndNoDeadLetterRoutingKey()
     {
-        $mock = $this->getMockQueue('foo', 'message.type.foo', $this->once());
-        $mock2 = $this->getMockQueue('bar', 'message.type.foo', $this->never());
-        $fooBackend = array('type' => 'message.type.foo', 'backend' => $mock);
-        $barBackend = array('type' => 'message.type.bar', 'backend' => $mock2);
-        $backends = array($fooBackend, $barBackend);
-        $dispatcher = $this->getDispatcher($backends);
-        $dispatcher->createAndPublish('message.type.foo', array());
+        list($backend, $channelMock) = $this->getBackendAndChannelMock();
+
+        $channelMock->expects($this->once())
+            ->method('exchange_declare')
+            ->with($this->equalTo(self::EXCHANGE),
+                   $this->equalTo('direct'),
+                   $this->isType('boolean'),
+                   $this->isType('boolean'),
+                   $this->isType('boolean')
+             );
+        $channelMock->expects($this->once())
+            ->method('queue_declare')
+            ->with($this->equalTo(self::QUEUE),
+                   $this->isType('boolean'),
+                   $this->isType('boolean'),
+                   $this->isType('boolean'),
+                   $this->isType('boolean'),
+                   $this->isType('boolean'),
+                   $this->equalTo(array())
+             );
+        $channelMock->expects($this->once())
+            ->method('queue_bind')
+            ->with($this->equalTo(self::QUEUE),
+                   $this->equalTo(self::EXCHANGE),
+                   $this->equalTo(self::KEY)
+             );
+
+        $backend->initialize();
     }
 
-    public function testDefaultQueue()
+    public function testInitializeWithDeadLetterExchangeAndNoDeadLetterRoutingKey()
     {
-        $mock = $this->getMockQueue('foo', 'message.type.foo', $this->once());
-        $fooBackend = array('type' => 'default', 'backend' => $mock);
-        $dispatcher = $this->getDispatcher(array($fooBackend));
-        $dispatcher->createAndPublish('some.other.type', array());
+        list($backend, $channelMock) = $this->getBackendAndChannelMock(false, self::DEAD_LETTER_EXCHANGE);
+
+        $channelMock->expects($this->exactly(2))
+            ->method('exchange_declare')
+            ->withConsecutive(
+                array(
+                    $this->equalTo(self::EXCHANGE),
+                    $this->equalTo('direct'),
+                    $this->isType('boolean'),
+                    $this->isType('boolean'),
+                    $this->isType('boolean'),
+                )
+             );
+        $channelMock->expects($this->once())
+            ->method('queue_declare')
+            ->with($this->equalTo(self::QUEUE),
+                   $this->isType('boolean'),
+                   $this->isType('boolean'),
+                   $this->isType('boolean'),
+                   $this->isType('boolean'),
+                   $this->isType('boolean'),
+                   $this->equalTo(array(
+                       'x-dead-letter-exchange' => array('S', self::DEAD_LETTER_EXCHANGE),
+                   ))
+             );
+        $channelMock->expects($this->exactly(2))
+            ->method('queue_bind')
+            ->withConsecutive(
+                array(
+                   $this->equalTo(self::QUEUE),
+                   $this->equalTo(self::EXCHANGE),
+                   $this->equalTo(self::KEY),
+                ),
+                array(
+                   $this->equalTo(self::QUEUE),
+                   $this->equalTo(self::DEAD_LETTER_EXCHANGE),
+                   $this->equalTo(self::KEY),
+                )
+             );
+
+        $backend->initialize();
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
-    public function testDefaultQueueNotFound()
+    public function testInitializeWithDeadLetterExchangeAndDeadLetterRoutingKey()
     {
-        $mock = $this->getMockQueue('foo', 'message.type.foo', $this->never());
-        $fooBackend = array('type' => 'message.type.foo', 'backend' => $mock);
-        $dispatcher = $this->getDispatcher(array($fooBackend));
-        $dispatcher->createAndPublish('some.other.type', array());
+        list($backend, $channelMock) = $this->getBackendAndChannelMock(false, self::DEAD_LETTER_EXCHANGE, self::DEAD_LETTER_ROUTING_KEY);
+
+        $channelMock->expects($this->once())
+            ->method('exchange_declare')
+            ->with($this->equalTo(self::EXCHANGE),
+                   $this->equalTo('direct'),
+                   $this->isType('boolean'),
+                   $this->isType('boolean'),
+                   $this->isType('boolean')
+             );
+        $channelMock->expects($this->once())
+            ->method('queue_declare')
+            ->with($this->equalTo(self::QUEUE),
+                   $this->isType('boolean'),
+                   $this->isType('boolean'),
+                   $this->isType('boolean'),
+                   $this->isType('boolean'),
+                   $this->isType('boolean'),
+                   $this->equalTo(array(
+                       'x-dead-letter-exchange' => array('S', self::DEAD_LETTER_EXCHANGE),
+                       'x-dead-letter-routing-key' => array('S', self::DEAD_LETTER_ROUTING_KEY),
+                   ))
+             );
+        $channelMock->expects($this->once())
+            ->method('queue_bind')
+            ->with($this->equalTo(self::QUEUE),
+                   $this->equalTo(self::EXCHANGE),
+                   $this->equalTo(self::KEY)
+             );
+
+        $backend->initialize();
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
-    public function testInvalidQueue()
+    protected function getBackendAndChannelMock($recover = false, $deadLetterExchange = null, $deadLetterRoutingKey = null)
     {
-        $mock = $this->getMockQueue('foo', 'message.type.bar');
-        $dispatcher = $this->getDispatcher(array(array('type' => 'bar', 'backend' => $mock)), 'foo', 'message.type.bar');
-        $dispatcher->createAndPublish('message.type.bar', array());
-    }
+        $mock = $this->getMockBuilder('\Sonata\NotificationBundle\Backend\AMQPBackend')
+            ->setConstructorArgs(array(self::EXCHANGE, self::QUEUE, $recover, self::KEY, $deadLetterExchange, $deadLetterRoutingKey))
+            ->setMethods(array('getIterator'))
+            ->getMock();
 
-    protected function getMockQueue($queue, $type, $called = null)
-    {
-        $methods = array('createAndPublish');
-        $args = array(array(), '', 'foo', 'message.type.foo');
-        $mock = $this->getMock('Sonata\NotificationBundle\Backend\AMQPBackend', $methods, $args);
-
-        if ($called !== null) {
-            $mock->expects($called)
-                ->method('createAndPublish')
-            ;
-        }
-
-        return $mock;
-    }
-
-    protected function getDispatcher(array $backends, $queue = 'foo', $key = 'message.type.foo')
-    {
-        $queues = array(array('queue' => $queue, 'routing_key' => $key));
         $settings = array(
-                'host' => 'foo',
-                'port' => 'port',
-                'user' => 'user',
-                'pass' => 'pass',
-                'vhost' => '/',
+            'host' => 'foo',
+            'port' => 'port',
+            'user' => 'user',
+            'pass' => 'pass',
+            'vhost' => '/',
         );
 
-        return new AMQPBackendDispatcher($settings, $queues, 'default', $backends);
+        $queues = array(
+            array('queue' => self::QUEUE, 'routing_key' => self::KEY),
+        );
+
+        $channelMock = $this->getMockBuilder('\PhpAmqpLib\Channel\AMQPChannel')
+            ->disableOriginalConstructor()
+            ->setMethods(array('queue_declare', 'exchange_declare', 'queue_bind'))
+            ->getMock()
+        ;
+
+        $dispatcherMock = $this->getMockBuilder('\Sonata\NotificationBundle\Backend\AMQPBackendDispatcher')
+            ->setConstructorArgs(array($settings, $queues, 'default', array(array('type' => self::KEY, 'backend' => $mock))))
+            ->setMethods(array('getChannel'))
+            ->getMock();
+
+        $dispatcherMock->method('getChannel')
+            ->willReturn($channelMock);
+
+        $mock->setDispatcher($dispatcherMock);
+
+        return array($mock, $channelMock);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this feature slightly changes the behavior, but basically does not give adverse effects.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
-  Add dead letter handling in AMQPBackend
```
<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject

<!-- Describe your Pull Request content here -->

Currently, just by setting "dead_letter_exchange" in "queues" configuration,
dead-letter-exchange will not be created  in rabbitMQ and the dead-lettered message
will simply be discarded.

In this feature, dead-letter-exchange will be created by "dead_letter_exchange" setting,
and enable to handle dead-letters by consumer started by "sonata:notification:start" command.

New configuration "dead_letter_routing_key" in "queues" setting routes dead-letters to specific queue.
This allows a dedicated consumer to handle the dead-letters. 

If "dead_letter_exchange"  is set and "dead_letter_routing_key" is not set, 
dead-lettered message will be requeued to original queue.