### PR TITLE
Added per-queue message TTL in AMQPBackend

### DIFF
--- a/Backend/AMQPBackend.php
+++ b/Backend/AMQPBackend.php
@@ -113,6 +113,7 @@ class AMQPBackend implements BackendInterface
                 $args['x-dead-letter-routing-key'] = array('S', $this->deadLetterRoutingKey);
             }
         }
+
         if ($this->ttl !== null) {
             $args['x-message-ttl'] = array('I', $this->ttl);
         }

--- a/Backend/AMQPBackend.php
+++ b/Backend/AMQPBackend.php
@@ -58,19 +58,25 @@ class AMQPBackend implements BackendInterface
     protected $deadLetterRoutingKey;
 
     /**
+     * @var null|int
+     */
+    protected $ttl;
+
+    /**
      * @var AMQPBackendDispatcher
      */
     protected $dispatcher = null;
 
     /**
-     * @param string $exchange
-     * @param string $queue
-     * @param string $recover
-     * @param string $key
-     * @param string $deadLetterExchange
-     * @param string $deadLetterRoutingKey
+     * @param string   $exchange
+     * @param string   $queue
+     * @param string   $recover
+     * @param string   $key
+     * @param string   $deadLetterExchange
+     * @param string   $deadLetterRoutingKey
+     * @param null|int $ttl
      */
-    public function __construct($exchange, $queue, $recover, $key, $deadLetterExchange = null, $deadLetterRoutingKey = null)
+    public function __construct($exchange, $queue, $recover, $key, $deadLetterExchange = null, $deadLetterRoutingKey = null, $ttl = null)
     {
         $this->exchange = $exchange;
         $this->queue = $queue;
@@ -78,6 +84,7 @@ class AMQPBackend implements BackendInterface
         $this->key = $key;
         $this->deadLetterExchange = $deadLetterExchange;
         $this->deadLetterRoutingKey = $deadLetterRoutingKey;
+        $this->ttl = $ttl;
 
         if (!class_exists('PhpAmqpLib\Message\AMQPMessage')) {
             throw new \RuntimeException('Please install php-amqplib/php-amqplib dependency');
@@ -105,6 +112,9 @@ class AMQPBackend implements BackendInterface
             if ($this->deadLetterRoutingKey !== null) {
                 $args['x-dead-letter-routing-key'] = array('S', $this->deadLetterRoutingKey);
             }
+        }
+        if ($this->ttl !== null) {
+            $args['x-message-ttl'] = array('I', $this->ttl);
         }
 
         /*

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -222,6 +222,12 @@ otherwise it will be requeued to the original queue if `dead-letter-exchange` is
 If set, the queue must be configured with this key as `routing_key`.
 EOF;
 
+        $ttl = <<<'EOF'
+Only used by RabbitMQ
+
+Defines the per-queue message time-to-live (milliseconds)
+EOF;
+
         $typesInfo = <<<'EOF'
 Only used by Doctrine
 
@@ -261,6 +267,11 @@ EOF;
                 ->end()
                 ->scalarNode('dead_letter_routing_key')
                     ->info($deadLetterRoutingKey)
+                    ->defaultValue(null)
+                ->end()
+                ->integerNode('ttl')
+                    ->info($ttl)
+                    ->min(0)
                     ->defaultValue(null)
                 ->end()
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -213,7 +213,7 @@ Only used by RabbitMQ
 If is set, failed messages will be rejected and sent to this exchange
 EOF;
 
-        $deadLetterRoutingKey = <<<'EOF'
+        $deadLetterRoutingKeyInfo = <<<'EOF'
 Only used by RabbitMQ
 
 If set, failed messages will be routed to the queue using this key by dead-letter-exchange,
@@ -222,7 +222,7 @@ otherwise it will be requeued to the original queue if `dead-letter-exchange` is
 If set, the queue must be configured with this key as `routing_key`.
 EOF;
 
-        $ttl = <<<'EOF'
+        $ttlInfo = <<<'EOF'
 Only used by RabbitMQ
 
 Defines the per-queue message time-to-live (milliseconds)
@@ -266,11 +266,11 @@ EOF;
                     ->defaultValue(null)
                 ->end()
                 ->scalarNode('dead_letter_routing_key')
-                    ->info($deadLetterRoutingKey)
+                    ->info($deadLetterRoutingKeyInfo)
                     ->defaultValue(null)
                 ->end()
                 ->integerNode('ttl')
-                    ->info($ttl)
+                    ->info($ttlInfo)
                     ->min(0)
                     ->defaultValue(null)
                 ->end()

--- a/DependencyInjection/SonataNotificationExtension.php
+++ b/DependencyInjection/SonataNotificationExtension.php
@@ -330,6 +330,7 @@ class SonataNotificationExtension extends Extension
                 'recover' => false,
                 'dead_letter_exchange' => null,
                 'dead_letter_routing_key' => null,
+                'ttl' => null,
             ));
         }
 
@@ -375,7 +376,8 @@ class SonataNotificationExtension extends Extension
                 $queue['recover'],
                 $queue['routing_key'],
                 $queue['dead_letter_exchange'],
-                $queue['dead_letter_routing_key']
+                $queue['dead_letter_routing_key'],
+                $queue['ttl']
             );
 
             $amqBackends[$pos] = array(
@@ -412,10 +414,11 @@ class SonataNotificationExtension extends Extension
      * @param string           $key
      * @param string           $deadLetterExchange
      * @param string           $deadLetterRoutingKey
+     * @param int|null         $ttl
      *
      * @return string
      */
-    protected function createAMQPBackend(ContainerBuilder $container, $exchange, $name, $recover, $key = '', $deadLetterExchange = null, $deadLetterRoutingKey = null)
+    protected function createAMQPBackend(ContainerBuilder $container, $exchange, $name, $recover, $key = '', $deadLetterExchange = null, $deadLetterRoutingKey = null, $ttl = null)
     {
         $id = 'sonata.notification.backend.rabbitmq.'.$this->amqpCounter++;
 
@@ -428,6 +431,7 @@ class SonataNotificationExtension extends Extension
                 $key,
                 $deadLetterExchange,
                 $deadLetterRoutingKey,
+                $ttl,
             )
         );
         $definition->setPublic(false);

--- a/Tests/Backend/AMQPBackendTest.php
+++ b/Tests/Backend/AMQPBackendTest.php
@@ -33,27 +33,30 @@ class AMQPBackendTest extends \PHPUnit_Framework_TestCase
 
         $channelMock->expects($this->once())
             ->method('exchange_declare')
-            ->with($this->equalTo(self::EXCHANGE),
-                   $this->equalTo('direct'),
-                   $this->isType('boolean'),
-                   $this->isType('boolean'),
-                   $this->isType('boolean')
+            ->with(
+                $this->equalTo(self::EXCHANGE),
+                $this->equalTo('direct'),
+                $this->isType('boolean'),
+                $this->isType('boolean'),
+                $this->isType('boolean')
              );
         $channelMock->expects($this->once())
             ->method('queue_declare')
-            ->with($this->equalTo(self::QUEUE),
-                   $this->isType('boolean'),
-                   $this->isType('boolean'),
-                   $this->isType('boolean'),
-                   $this->isType('boolean'),
-                   $this->isType('boolean'),
-                   $this->equalTo(array())
+            ->with(
+                $this->equalTo(self::QUEUE),
+                $this->isType('boolean'),
+                $this->isType('boolean'),
+                $this->isType('boolean'),
+                $this->isType('boolean'),
+                $this->isType('boolean'),
+                $this->equalTo(array())
              );
         $channelMock->expects($this->once())
             ->method('queue_bind')
-            ->with($this->equalTo(self::QUEUE),
-                   $this->equalTo(self::EXCHANGE),
-                   $this->equalTo(self::KEY)
+            ->with(
+                $this->equalTo(self::QUEUE),
+                $this->equalTo(self::EXCHANGE),
+                $this->equalTo(self::KEY)
              );
 
         $backend->initialize();
@@ -83,15 +86,16 @@ class AMQPBackendTest extends \PHPUnit_Framework_TestCase
              );
         $channelMock->expects($this->once())
             ->method('queue_declare')
-            ->with($this->equalTo(self::QUEUE),
-                   $this->isType('boolean'),
-                   $this->isType('boolean'),
-                   $this->isType('boolean'),
-                   $this->isType('boolean'),
-                   $this->isType('boolean'),
-                   $this->equalTo(array(
-                       'x-dead-letter-exchange' => array('S', self::DEAD_LETTER_EXCHANGE),
-                   ))
+            ->with(
+                $this->equalTo(self::QUEUE),
+                $this->isType('boolean'),
+                $this->isType('boolean'),
+                $this->isType('boolean'),
+                $this->isType('boolean'),
+                $this->isType('boolean'),
+                $this->equalTo(array(
+                    'x-dead-letter-exchange' => array('S', self::DEAD_LETTER_EXCHANGE),
+                ))
              );
         $channelMock->expects($this->exactly(2))
             ->method('queue_bind')
@@ -117,30 +121,33 @@ class AMQPBackendTest extends \PHPUnit_Framework_TestCase
 
         $channelMock->expects($this->once())
             ->method('exchange_declare')
-            ->with($this->equalTo(self::EXCHANGE),
-                   $this->equalTo('direct'),
-                   $this->isType('boolean'),
-                   $this->isType('boolean'),
-                   $this->isType('boolean')
+            ->with(
+                $this->equalTo(self::EXCHANGE),
+                $this->equalTo('direct'),
+                $this->isType('boolean'),
+                $this->isType('boolean'),
+                $this->isType('boolean')
              );
         $channelMock->expects($this->once())
             ->method('queue_declare')
-            ->with($this->equalTo(self::QUEUE),
-                   $this->isType('boolean'),
-                   $this->isType('boolean'),
-                   $this->isType('boolean'),
-                   $this->isType('boolean'),
-                   $this->isType('boolean'),
-                   $this->equalTo(array(
-                       'x-dead-letter-exchange' => array('S', self::DEAD_LETTER_EXCHANGE),
-                       'x-dead-letter-routing-key' => array('S', self::DEAD_LETTER_ROUTING_KEY),
-                   ))
+            ->with(
+                $this->equalTo(self::QUEUE),
+                $this->isType('boolean'),
+                $this->isType('boolean'),
+                $this->isType('boolean'),
+                $this->isType('boolean'),
+                $this->isType('boolean'),
+                $this->equalTo(array(
+                   'x-dead-letter-exchange' => array('S', self::DEAD_LETTER_EXCHANGE),
+                   'x-dead-letter-routing-key' => array('S', self::DEAD_LETTER_ROUTING_KEY),
+                ))
              );
         $channelMock->expects($this->once())
             ->method('queue_bind')
-            ->with($this->equalTo(self::QUEUE),
-                   $this->equalTo(self::EXCHANGE),
-                   $this->equalTo(self::KEY)
+            ->with(
+                $this->equalTo(self::QUEUE),
+                $this->equalTo(self::EXCHANGE),
+                $this->equalTo(self::KEY)
              );
 
         $backend->initialize();
@@ -152,29 +159,32 @@ class AMQPBackendTest extends \PHPUnit_Framework_TestCase
 
         $channelMock->expects($this->once())
             ->method('exchange_declare')
-            ->with($this->equalTo(self::EXCHANGE),
-                   $this->equalTo('direct'),
-                   $this->isType('boolean'),
-                   $this->isType('boolean'),
-                   $this->isType('boolean')
+            ->with(
+                $this->equalTo(self::EXCHANGE),
+                $this->equalTo('direct'),
+                $this->isType('boolean'),
+                $this->isType('boolean'),
+                $this->isType('boolean')
              );
         $channelMock->expects($this->once())
             ->method('queue_declare')
-            ->with($this->equalTo(self::QUEUE),
-                   $this->isType('boolean'),
-                   $this->isType('boolean'),
-                   $this->isType('boolean'),
-                   $this->isType('boolean'),
-                   $this->isType('boolean'),
-                   $this->equalTo(array(
-                       'x-message-ttl' => array('I', self::TTL),
-                   ))
+            ->with(
+                $this->equalTo(self::QUEUE),
+                $this->isType('boolean'),
+                $this->isType('boolean'),
+                $this->isType('boolean'),
+                $this->isType('boolean'),
+                $this->isType('boolean'),
+                $this->equalTo(array(
+                    'x-message-ttl' => array('I', self::TTL),
+                ))
              );
         $channelMock->expects($this->once())
             ->method('queue_bind')
-            ->with($this->equalTo(self::QUEUE),
-                   $this->equalTo(self::EXCHANGE),
-                   $this->equalTo(self::KEY)
+            ->with(
+                $this->equalTo(self::QUEUE),
+                $this->equalTo(self::EXCHANGE),
+                $this->equalTo(self::KEY)
              );
 
         $backend->initialize();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this change has no influence on current configurations/features,
only add the new feature.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added per-queue message TTL in AMQPBackend
```
<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject

<!-- Describe your Pull Request content here -->
This enables to configure the "Per-Queue Message TTL" in RabbitMQ.
reference: https://www.rabbitmq.com/ttl.html