### PR TITLE
Upgrade FOS-Rest bundle to 2.1

### DIFF
--- a/Controller/Api/MessageController.php
+++ b/Controller/Api/MessageController.php
@@ -12,6 +12,7 @@
 namespace Sonata\NotificationBundle\Controller\Api;
 
 use FOS\RestBundle\Context\Context;
+use JMS\Serializer\SerializationContext;
 use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\Route;
 use FOS\RestBundle\Controller\Annotations\View;
@@ -64,7 +65,6 @@ class MessageController
      *
      * @QueryParam(name="page", requirements="\d+", default="1", description="Page for message list pagination")
      * @QueryParam(name="count", requirements="\d+", default="10", description="Number of messages by page")
-     * @QueryParam(name="orderBy", map=true, requirements="ASC|DESC", nullable=true, strict=true, description="Order by array (key is field, value is direction)")
      * @QueryParam(name="type", nullable=true, description="Message type filter")
      * @QueryParam(name="state", requirements="\d+", strict=true, nullable=true, description="Message status filter")
      *
@@ -76,6 +76,20 @@ class MessageController
      */
     public function getMessagesAction(ParamFetcherInterface $paramFetcher)
     {
+        $orderByQueryParam = new QueryParam();
+        $orderByQueryParam->name = 'orderBy';
+        $orderByQueryParam->requirements = 'ASC|DESC';
+        $orderByQueryParam->nullable = true;
+        $orderByQueryParam->strict = true;
+        $orderByQueryParam->description = 'Query groups order by clause (key is field, value is direction)';
+        if (property_exists($orderByQueryParam, 'map')) {
+            $orderByQueryParam->map = true;
+        } else {
+           $orderByQueryParam->array = true;
+        }
+
+        $paramFetcher->addParam($orderByQueryParam);
+
         $supportedCriteria = array(
             'state' => '',
             'type' => '',
@@ -135,9 +149,16 @@ class MessageController
             $this->messageManager->save($message);
 
             $view = FOSRestView::create($message);
-            $serializationContext = new Context();
+
+            if (class_exists('FOS\RestBundle\Context\Context')) {
+                $serializationContext = new Context();
+                $serializationContext->enableMaxDepth();
+            } else {
+                $serializationContext = SerializationContext::create();
+                $serializationContext->enableMaxDepthChecks();
+            }
             $serializationContext->setGroups(array('sonata_api_read'));
-            $serializationContext->enableMaxDepth();
+
             $view->setContext($serializationContext);
 
             return $view;

--- a/Controller/Api/MessageController.php
+++ b/Controller/Api/MessageController.php
@@ -47,7 +47,7 @@ class MessageController
      * Constructor.
      *
      * @param MessageManagerInterface $messageManager
-     * @param FormFactoryInterface $formFactory
+     * @param FormFactoryInterface    $formFactory
      */
     public function __construct(MessageManagerInterface $messageManager, FormFactoryInterface $formFactory)
     {

--- a/Controller/Api/MessageController.php
+++ b/Controller/Api/MessageController.php
@@ -12,12 +12,12 @@
 namespace Sonata\NotificationBundle\Controller\Api;
 
 use FOS\RestBundle\Context\Context;
-use JMS\Serializer\SerializationContext;
 use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\Route;
 use FOS\RestBundle\Controller\Annotations\View;
 use FOS\RestBundle\Request\ParamFetcherInterface;
 use FOS\RestBundle\View\View as FOSRestView;
+use JMS\Serializer\SerializationContext;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\NotificationBundle\Model\MessageInterface;

--- a/Controller/Api/MessageController.php
+++ b/Controller/Api/MessageController.php
@@ -85,7 +85,7 @@ class MessageController
         if (property_exists($orderByQueryParam, 'map')) {
             $orderByQueryParam->map = true;
         } else {
-           $orderByQueryParam->array = true;
+            $orderByQueryParam->array = true;
         }
 
         $paramFetcher->addParam($orderByQueryParam);

--- a/Controller/Api/MessageController.php
+++ b/Controller/Api/MessageController.php
@@ -11,12 +11,12 @@
 
 namespace Sonata\NotificationBundle\Controller\Api;
 
+use FOS\RestBundle\Context\Context;
 use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\Route;
 use FOS\RestBundle\Controller\Annotations\View;
 use FOS\RestBundle\Request\ParamFetcherInterface;
 use FOS\RestBundle\View\View as FOSRestView;
-use JMS\Serializer\SerializationContext;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\NotificationBundle\Model\MessageInterface;
@@ -64,7 +64,7 @@ class MessageController
      *
      * @QueryParam(name="page", requirements="\d+", default="1", description="Page for message list pagination")
      * @QueryParam(name="count", requirements="\d+", default="10", description="Number of messages by page")
-     * @QueryParam(name="orderBy", array=true, requirements="ASC|DESC", nullable=true, strict=true, description="Order by array (key is field, value is direction)")
+     * @QueryParam(name="orderBy", map=true, requirements="ASC|DESC", nullable=true, strict=true, description="Order by array (key is field, value is direction)")
      * @QueryParam(name="type", nullable=true, description="Message type filter")
      * @QueryParam(name="state", requirements="\d+", strict=true, nullable=true, description="Message status filter")
      *
@@ -135,10 +135,10 @@ class MessageController
             $this->messageManager->save($message);
 
             $view = FOSRestView::create($message);
-            $serializationContext = SerializationContext::create();
+            $serializationContext = new Context();
             $serializationContext->setGroups(array('sonata_api_read'));
-            $serializationContext->enableMaxDepthChecks();
-            $view->setSerializationContext($serializationContext);
+            $serializationContext->enableMaxDepth();
+            $view->setContext($serializationContext);
 
             return $view;
         }

--- a/Controller/Api/MessageController.php
+++ b/Controller/Api/MessageController.php
@@ -47,7 +47,7 @@ class MessageController
      * Constructor.
      *
      * @param MessageManagerInterface $messageManager
-     * @param FormFactoryInterface    $formFactory
+     * @param FormFactoryInterface $formFactory
      */
     public function __construct(MessageManagerInterface $messageManager, FormFactoryInterface $formFactory)
     {
@@ -152,14 +152,19 @@ class MessageController
 
             if (class_exists('FOS\RestBundle\Context\Context')) {
                 $serializationContext = new Context();
-                $serializationContext->enableMaxDepth();
+                if (method_exists($serializationContext, 'enableMaxDepth')) {
+                    $serializationContext->enableMaxDepth();
+                } else {
+                    $serializationContext->setMaxDepth(10);
+                }
+                $serializationContext->setGroups(array('sonata_api_read'));
+                $view->setContext($serializationContext);
             } else {
                 $serializationContext = SerializationContext::create();
                 $serializationContext->enableMaxDepthChecks();
+                $serializationContext->setGroups(array('sonata_api_read'));
+                $view->setSerializationContext($serializationContext);
             }
-            $serializationContext->setGroups(array('sonata_api_read'));
-
-            $view->setContext($serializationContext);
 
             return $view;
         }

--- a/Tests/Controller/Api/MessageControllerTest.php
+++ b/Tests/Controller/Api/MessageControllerTest.php
@@ -27,7 +27,9 @@ class MessageControllerTest extends \PHPUnit_Framework_TestCase
         $messageManager = $this->getMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
         $messageManager->expects($this->once())->method('getPager')->will($this->returnValue(array()));
 
-        $paramFetcher = $this->getMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher = $this->getMockBuilder('FOS\RestBundle\Request\ParamFetcher')
+            ->disableOriginalConstructor()
+            ->getMock();
         $paramFetcher->expects($this->exactly(3))->method('get');
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue(array()));
 

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "liip/monitor-bundle": "^2.0",
         "symfony/phpunit-bridge": "^2.7 || ^3.0",
         "swiftmailer/swiftmailer": "^4.3 || ^5.0",
-        "friendsofsymfony/rest-bundle": "^1.1 || ^2.1",
+        "friendsofsymfony/rest-bundle": "^1.5 || ^2.1",
         "jms/serializer-bundle": "^0.13 || ^1.0",
         "nelmio/api-doc-bundle": "^2.4",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "liip/monitor-bundle": "^2.0",
         "symfony/phpunit-bridge": "^2.7 || ^3.0",
         "swiftmailer/swiftmailer": "^4.3 || ^5.0",
-        "friendsofsymfony/rest-bundle": "^2.1",
+        "friendsofsymfony/rest-bundle": "^1.1 || ^2.1",
         "jms/serializer-bundle": "^0.13 || ^1.0",
         "nelmio/api-doc-bundle": "^2.4",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "liip/monitor-bundle": "^2.0",
         "symfony/phpunit-bridge": "^2.7 || ^3.0",
         "swiftmailer/swiftmailer": "^4.3 || ^5.0",
-        "friendsofsymfony/rest-bundle": "^1.1",
+        "friendsofsymfony/rest-bundle": "^2.1",
         "jms/serializer-bundle": "^0.13 || ^1.0",
         "nelmio/api-doc-bundle": "^2.4",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0"


### PR DESCRIPTION
I am targetting this branch, because updating to FOS-Rest in version 2.1 will break the 1.x BC.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Changed
- array `QueryParam` parameter to map
- FosRest `SerializationContext` to `Context`
```


<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->


## Subject

When updating to the 2.x Version of the FOS-Rest bundle the Message Controller will break due to renaming on their part. This pull request aims to fix change the controller in such a way that it is compatible with the 2.x Versions of the FOS-Rest bundle 
