### PR TITLE
Add support for cc/bcc in SwiftMailerConsumer

### DIFF
--- a/Consumer/SwiftMailerConsumer.php
+++ b/Consumer/SwiftMailerConsumer.php
@@ -69,6 +69,10 @@ class SwiftMailerConsumer implements ConsumerInterface
             $mail->setCc($cc);
         }
 
+        if ($bcc = $message->getValue('bcc')) {
+            $mail->setBcc($bcc);
+        }
+
         if ($text = $message->getValue(array('message', 'text'))) {
             $mail->addPart($text, 'text/plain');
         }

--- a/Consumer/SwiftMailerConsumer.php
+++ b/Consumer/SwiftMailerConsumer.php
@@ -65,6 +65,10 @@ class SwiftMailerConsumer implements ConsumerInterface
             $mail->setReplyTo($replyTo);
         }
 
+        if ($cc = $message->getValue('cc')) {
+            $mail->setCc($cc);
+        }
+
         if ($text = $message->getValue(array('message', 'text'))) {
             $mail->addPart($text, 'text/plain');
         }

--- a/Tests/Consumer/SwiftMailerConsumerTest.php
+++ b/Tests/Consumer/SwiftMailerConsumerTest.php
@@ -65,6 +65,10 @@ class SwiftMailerConsumerTest extends \PHPUnit_Framework_TestCase
                 'cc1@mail.fr',
                 'cc2@mail.fr' => 'nameCc2',
             ),
+            'bcc' => array(
+                'bcc1@mail.fr',
+                'bcc2@mail.fr' => 'nameBcc2',
+            ),
             'message' => array(
                 'text' => 'message text',
                 'html' => 'message html',
@@ -79,6 +83,10 @@ class SwiftMailerConsumerTest extends \PHPUnit_Framework_TestCase
         $mail->expects($this->once())
             ->method('setCc')
             ->with($this->equalTo(array('cc1@mail.fr', 'cc2@mail.fr' => 'nameCc2')))
+            ->willReturnSelf();
+        $mail->expects($this->once())
+            ->method('setBcc')
+            ->with($this->equalTo(array('bcc1@mail.fr', 'bcc2@mail.fr' => 'nameBcc2')))
             ->willReturnSelf();
         $mail->expects($this->exactly(2))
             ->method('addPart')

--- a/Tests/Consumer/SwiftMailerConsumerTest.php
+++ b/Tests/Consumer/SwiftMailerConsumerTest.php
@@ -61,6 +61,10 @@ class SwiftMailerConsumerTest extends \PHPUnit_Framework_TestCase
                 'replyTo1@mail.fr',
                 'replyTo2@mail.fr' => 'nameReplyTo2',
             ),
+            'cc' => array(
+                'cc1@mail.fr',
+                'cc2@mail.fr' => 'nameCc2',
+            ),
             'message' => array(
                 'text' => 'message text',
                 'html' => 'message html',
@@ -72,6 +76,10 @@ class SwiftMailerConsumerTest extends \PHPUnit_Framework_TestCase
         $mail->expects($this->once())->method('setFrom')->with($this->equalTo(array('from@mail.fr' => 'nameFrom')))->willReturnSelf();
         $mail->expects($this->once())->method('setTo')->with($this->equalTo(array('to1@mail.fr', 'to2@mail.fr' => 'nameTo2')))->willReturnSelf();
         $mail->expects($this->once())->method('setReplyTo')->with($this->equalTo(array('replyTo1@mail.fr', 'replyTo2@mail.fr' => 'nameReplyTo2')))->willReturnSelf();
+        $mail->expects($this->once())
+            ->method('setCc')
+            ->with($this->equalTo(array('cc1@mail.fr', 'cc2@mail.fr' => 'nameCc2')))
+            ->willReturnSelf();
         $mail->expects($this->exactly(2))
             ->method('addPart')
             ->withConsecutive(


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is an enhancement.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Support for cc/bcc fields in `SwiftMailerConsumer`

```
