### PR TITLE
use createMock() instead of deprecated getMock()

### DIFF
--- a/Tests/Backend/AMQPBackendDispatcherTest.php
+++ b/Tests/Backend/AMQPBackendDispatcherTest.php
@@ -12,8 +12,9 @@
 namespace Sonata\NotificationBundle\Tests\Backend;
 
 use Sonata\NotificationBundle\Backend\AMQPBackendDispatcher;
+use Sonata\NotificationBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class AMQPBackendDispatcherTest extends \PHPUnit_Framework_TestCase
+class AMQPBackendDispatcherTest extends PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {

--- a/Tests/Backend/AMQPBackendTest.php
+++ b/Tests/Backend/AMQPBackendTest.php
@@ -11,7 +11,9 @@
 
 namespace Sonata\NotificationBundle\Tests\Backend;
 
-class AMQPBackendTest extends \PHPUnit_Framework_TestCase
+use Sonata\NotificationBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
+
+class AMQPBackendTest extends PHPUnit_Framework_TestCase
 {
     const EXCHANGE = 'exchange';
     const QUEUE = 'foo';

--- a/Tests/Backend/BackendHealthCheckTest.php
+++ b/Tests/Backend/BackendHealthCheckTest.php
@@ -12,9 +12,10 @@
 namespace Sonata\NotificationBundle\Tests\Notification;
 
 use Sonata\NotificationBundle\Backend\BackendHealthCheck;
+use Sonata\NotificationBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use ZendDiagnostics\Result\Success;
 
-class BackendHealthCheckTest extends \PHPUnit_Framework_TestCase
+class BackendHealthCheckTest extends PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
@@ -27,7 +28,7 @@ class BackendHealthCheckTest extends \PHPUnit_Framework_TestCase
     {
         $result = new Success('Test check', 'OK');
 
-        $backend = $this->getMock('Sonata\NotificationBundle\Backend\BackendInterface');
+        $backend = $this->createMock('Sonata\NotificationBundle\Backend\BackendInterface');
         $backend->expects($this->once())->method('getStatus')->will($this->returnValue($result));
 
         $health = new BackendHealthCheck($backend);

--- a/Tests/Backend/MessageManagerBackendDispatcherTest.php
+++ b/Tests/Backend/MessageManagerBackendDispatcherTest.php
@@ -13,18 +13,16 @@ namespace Sonata\NotificationBundle\Tests\Backend;
 
 use Sonata\NotificationBundle\Backend\MessageManagerBackendDispatcher;
 use Sonata\NotificationBundle\Model\Message;
+use Sonata\NotificationBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class MessageManagerBackendDispatcherTest extends \PHPUnit_Framework_TestCase
+class MessageManagerBackendDispatcherTest extends PHPUnit_Framework_TestCase
 {
     public function testCreate()
     {
-        $testBackend = $this->getMockBuilder('Sonata\NotificationBundle\Backend\MessageManagerBackend')
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
+        $testBackend = $this->createMock('Sonata\NotificationBundle\Backend\MessageManagerBackend');
 
         $testBackend->expects($this->once())
             ->method('setDispatcher')
@@ -39,7 +37,7 @@ class MessageManagerBackendDispatcherTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($message))
         ;
 
-        $mMgr = $this->getMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
+        $mMgr = $this->createMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
 
         $mMgrBackend = new MessageManagerBackendDispatcher($mMgr, array(), '', array(array('types' => array('test'), 'backend' => $testBackend)));
 

--- a/Tests/Backend/MessageManagerBackendTest.php
+++ b/Tests/Backend/MessageManagerBackendTest.php
@@ -15,16 +15,17 @@ use Sonata\NotificationBundle\Backend\MessageManagerBackend;
 use Sonata\NotificationBundle\Exception\HandlingException;
 use Sonata\NotificationBundle\Model\MessageInterface;
 use Sonata\NotificationBundle\Tests\Entity\Message;
+use Sonata\NotificationBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use ZendDiagnostics\Result\Failure;
 use ZendDiagnostics\Result\Success;
 use ZendDiagnostics\Result\Warning;
 
-class MessageManagerBackendTest extends \PHPUnit_Framework_TestCase
+class MessageManagerBackendTest extends PHPUnit_Framework_TestCase
 {
     public function testCreateAndPublish()
     {
         $message = new Message();
-        $modelManager = $this->getMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
+        $modelManager = $this->createMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
         $modelManager->expects($this->once())->method('save')->will($this->returnValue($message));
         $modelManager->expects($this->once())->method('create')->will($this->returnValue($message));
 
@@ -41,10 +42,10 @@ class MessageManagerBackendTest extends \PHPUnit_Framework_TestCase
     public function testHandleSuccess()
     {
         $message = new Message();
-        $modelManager = $this->getMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
+        $modelManager = $this->createMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
         $modelManager->expects($this->exactly(2))->method('save')->will($this->returnValue($message));
 
-        $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $dispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $dispatcher->expects($this->once())->method('dispatch');
 
         $backend = new MessageManagerBackend($modelManager, array());
@@ -59,10 +60,10 @@ class MessageManagerBackendTest extends \PHPUnit_Framework_TestCase
     public function testHandleError()
     {
         $message = new Message();
-        $modelManager = $this->getMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
+        $modelManager = $this->createMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
         $modelManager->expects($this->exactly(2))->method('save')->will($this->returnValue($message));
 
-        $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $dispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $dispatcher->expects($this->once())->method('dispatch')->will($this->throwException(new \RuntimeException()));
         $backend = new MessageManagerBackend($modelManager, array());
 
@@ -88,7 +89,7 @@ class MessageManagerBackendTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('The class ZendDiagnostics\Result\Success does not exist');
         }
 
-        $modelManager = $this->getMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
+        $modelManager = $this->createMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
         $modelManager->expects($this->exactly(1))->method('countStates')->will($this->returnValue($counts));
 
         $backend = new MessageManagerBackend($modelManager, array(

--- a/Tests/Backend/PostponeRuntimeBackendTest.php
+++ b/Tests/Backend/PostponeRuntimeBackendTest.php
@@ -14,16 +14,20 @@ namespace Sonata\NotificationBundle\Tests\Backend;
 use Sonata\NotificationBundle\Backend\PostponeRuntimeBackend;
 use Sonata\NotificationBundle\Consumer\ConsumerEventInterface;
 use Sonata\NotificationBundle\Model\MessageInterface;
+use Sonata\NotificationBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
  * @covers \Sonata\NotificationBundle\Backend\PostponeRuntimeBackend
  */
-class PostponeRuntimeBackendTest extends \PHPUnit_Framework_TestCase
+class PostponeRuntimeBackendTest extends PHPUnit_Framework_TestCase
 {
     public function testIteratorContainsPublishedMessages()
     {
-        $backend = new PostponeRuntimeBackend($this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface'), true);
+        $backend = new PostponeRuntimeBackend(
+            $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface'),
+            true
+        );
 
         $messages = array();
 
@@ -49,7 +53,11 @@ class PostponeRuntimeBackendTest extends \PHPUnit_Framework_TestCase
 
     public function testNoMessagesOnEvent()
     {
-        $backend = $this->getMock('Sonata\NotificationBundle\Backend\PostponeRuntimeBackend', array('handle'), array($this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface'), true));
+        $backend = $this->getMockBuilder('Sonata\NotificationBundle\Backend\PostponeRuntimeBackend')
+            ->setMethods(array('handle'))
+            ->setConstructorArgs(array($this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface')))
+            ->getMock();
+
         $backend
             ->expects($this->never())
             ->method('handle')
@@ -128,7 +136,10 @@ class PostponeRuntimeBackendTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('The class ZendDiagnostics\Result\Success does not exist');
         }
 
-        $backend = new PostponeRuntimeBackend($this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface'), true);
+        $backend = new PostponeRuntimeBackend(
+            $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface'),
+            true
+        );
 
         $status = $backend->getStatus();
         $this->assertInstanceOf('ZendDiagnostics\Result\Success', $status);
@@ -136,7 +147,11 @@ class PostponeRuntimeBackendTest extends \PHPUnit_Framework_TestCase
 
     public function testOnCliPublishHandlesDirectly()
     {
-        $backend = $this->getMock('Sonata\NotificationBundle\Backend\PostponeRuntimeBackend', array('handle'), array($this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface'), false));
+        $backend = $this->getMockBuilder('Sonata\NotificationBundle\Backend\PostponeRuntimeBackend')
+            ->setMethods(array('handle'))
+            ->setConstructorArgs(array($this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface')))
+            ->getMock();
+
         $backend
             ->expects($this->once())
             ->method('handle')

--- a/Tests/Backend/RuntimeBackendTest.php
+++ b/Tests/Backend/RuntimeBackendTest.php
@@ -15,12 +15,13 @@ use Sonata\NotificationBundle\Backend\RuntimeBackend;
 use Sonata\NotificationBundle\Exception\HandlingException;
 use Sonata\NotificationBundle\Model\MessageInterface;
 use Sonata\NotificationBundle\Tests\Entity\Message;
+use Sonata\NotificationBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class RuntimeBackendTest extends \PHPUnit_Framework_TestCase
+class RuntimeBackendTest extends PHPUnit_Framework_TestCase
 {
     public function testCreateAndPublish()
     {
-        $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $dispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $backend = new RuntimeBackend($dispatcher);
         $message = $backend->createAndPublish('foo', array('message' => 'salut'));
 
@@ -34,7 +35,7 @@ class RuntimeBackendTest extends \PHPUnit_Framework_TestCase
 
     public function testIterator()
     {
-        $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $dispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $backend = new RuntimeBackend($dispatcher);
 
         $this->assertInstanceOf('Iterator', $backend->getIterator());
@@ -44,7 +45,7 @@ class RuntimeBackendTest extends \PHPUnit_Framework_TestCase
     {
         $message = new Message();
 
-        $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $dispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $dispatcher->expects($this->once())->method('dispatch');
 
         $backend = new RuntimeBackend($dispatcher);
@@ -59,7 +60,7 @@ class RuntimeBackendTest extends \PHPUnit_Framework_TestCase
     {
         $message = new Message();
 
-        $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $dispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $dispatcher->expects($this->once())->method('dispatch')->will($this->throwException(new \RuntimeException()));
 
         $backend = new RuntimeBackend($dispatcher);

--- a/Tests/Consumer/LoggerConsumerTest.php
+++ b/Tests/Consumer/LoggerConsumerTest.php
@@ -14,8 +14,9 @@ namespace Sonata\NotificationBundle\Tests\Consumer;
 use Sonata\NotificationBundle\Consumer\ConsumerEvent;
 use Sonata\NotificationBundle\Consumer\LoggerConsumer;
 use Sonata\NotificationBundle\Tests\Entity\Message;
+use Sonata\NotificationBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class LoggerConsumerTest extends \PHPUnit_Framework_TestCase
+class LoggerConsumerTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider calledTypeProvider
@@ -25,7 +26,7 @@ class LoggerConsumerTest extends \PHPUnit_Framework_TestCase
      */
     public function testProcess($type, $calledType)
     {
-        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger = $this->createMock('Psr\Log\LoggerInterface');
         $logger->expects($this->once())->method($calledType);
 
         $message = new Message();
@@ -62,7 +63,7 @@ class LoggerConsumerTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidType()
     {
-        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger = $this->createMock('Psr\Log\LoggerInterface');
 
         $message = new Message();
         $message->setBody(array(

--- a/Tests/Consumer/SwiftMailerConsumerTest.php
+++ b/Tests/Consumer/SwiftMailerConsumerTest.php
@@ -13,11 +13,12 @@ namespace Sonata\NotificationBundle\Tests\Consumer;
 
 use Sonata\NotificationBundle\Consumer\SwiftMailerConsumer;
 use Sonata\NotificationBundle\Model\Message;
+use Sonata\NotificationBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 /**
  * Tests the SwiftMailerConsumer.
  */
-class SwiftMailerConsumerTest extends \PHPUnit_Framework_TestCase
+class SwiftMailerConsumerTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var SwiftMailerConsumer
@@ -34,10 +35,7 @@ class SwiftMailerConsumerTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->mailer = $this->getMockBuilder('Swift_Mailer')
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $this->mailer = $this->createMock('Swift_Mailer');
         $this->consumer = new SwiftMailerConsumer($this->mailer);
     }
 
@@ -75,7 +73,7 @@ class SwiftMailerConsumerTest extends \PHPUnit_Framework_TestCase
             ),
         ));
 
-        $mail = $this->getMockBuilder('Swift_Message')->disableOriginalConstructor()->getMock();
+        $mail = $this->createMock('Swift_Message');
         $mail->expects($this->once())->method('setSubject')->with($this->equalTo('subject'))->willReturnSelf();
         $mail->expects($this->once())->method('setFrom')->with($this->equalTo(array('from@mail.fr' => 'nameFrom')))->willReturnSelf();
         $mail->expects($this->once())->method('setTo')->with($this->equalTo(array('to1@mail.fr', 'to2@mail.fr' => 'nameTo2')))->willReturnSelf();

--- a/Tests/Controller/Api/MessageControllerTest.php
+++ b/Tests/Controller/Api/MessageControllerTest.php
@@ -12,21 +12,20 @@
 namespace Sonata\NotificationBundle\Tests\Controller\Api;
 
 use Sonata\NotificationBundle\Controller\Api\MessageController;
+use Sonata\NotificationBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class MessageControllerTest extends \PHPUnit_Framework_TestCase
+class MessageControllerTest extends PHPUnit_Framework_TestCase
 {
     public function testGetMessagesAction()
     {
-        $messageManager = $this->getMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
+        $messageManager = $this->createMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
         $messageManager->expects($this->once())->method('getPager')->will($this->returnValue(array()));
 
-        $paramFetcher = $this->getMockBuilder('FOS\RestBundle\Request\ParamFetcher')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $paramFetcher = $this->createMock('FOS\RestBundle\Request\ParamFetcher');
         $paramFetcher->expects($this->exactly(3))->method('get');
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue(array()));
 
@@ -35,17 +34,17 @@ class MessageControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPostMessageAction()
     {
-        $message = $this->getMock('Sonata\NotificationBundle\Model\MessageInterface');
+        $message = $this->createMock('Sonata\NotificationBundle\Model\MessageInterface');
 
-        $messageManager = $this->getMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
+        $messageManager = $this->createMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
         $messageManager->expects($this->once())->method('save')->will($this->returnValue($message));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->createMock('Symfony\Component\Form\Form');
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($message));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createMessageController(null, $messageManager, $formFactory)->postMessageAction(new Request());
@@ -55,16 +54,16 @@ class MessageControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPostMessageInvalidAction()
     {
-        $message = $this->getMock('Sonata\NotificationBundle\Model\MessageInterface');
+        $message = $this->createMock('Sonata\NotificationBundle\Model\MessageInterface');
 
-        $messageManager = $this->getMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
+        $messageManager = $this->createMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
         $messageManager->expects($this->never())->method('save')->will($this->returnValue($message));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->createMock('Symfony\Component\Form\Form');
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createMessageController(null, $messageManager, $formFactory)->postMessageAction(new Request());
@@ -82,13 +81,13 @@ class MessageControllerTest extends \PHPUnit_Framework_TestCase
     public function createMessageController($message = null, $messageManager = null, $formFactory = null)
     {
         if (null === $messageManager) {
-            $messageManager = $this->getMock('Sonata\PageBundle\Model\SiteManagerInterface');
+            $messageManager = $this->createMock('Sonata\PageBundle\Model\SiteManagerInterface');
         }
         if (null !== $message) {
             $messageManager->expects($this->once())->method('findOneBy')->will($this->returnValue($message));
         }
         if (null === $formFactory) {
-            $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+            $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         }
 
         return new MessageController($messageManager, $formFactory);

--- a/Tests/Entity/Message.php
+++ b/Tests/Entity/Message.php
@@ -13,6 +13,7 @@ namespace Sonata\NotificationBundle\Tests\Entity;
 
 use Sonata\NotificationBundle\Entity\BaseMessage;
 use Sonata\NotificationBundle\Model\MessageInterface;
+use Sonata\NotificationBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 class Message extends BaseMessage
 {
@@ -22,7 +23,7 @@ class Message extends BaseMessage
     }
 }
 
-class BaseMessageTest extends \PHPUnit_Framework_TestCase
+class BaseMessageTest extends PHPUnit_Framework_TestCase
 {
     public function testClone()
     {

--- a/Tests/Entity/MessageManagerTest.php
+++ b/Tests/Entity/MessageManagerTest.php
@@ -13,8 +13,9 @@ namespace Sonata\NotificationBundle\Tests\Entity;
 
 use Sonata\NotificationBundle\Entity\MessageManager;
 use Sonata\NotificationBundle\Model\MessageInterface;
+use Sonata\NotificationBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class MessageManagerTest extends \PHPUnit_Framework_TestCase
+class MessageManagerTest extends PHPUnit_Framework_TestCase
 {
     public function testCancel()
     {
@@ -147,7 +148,7 @@ class MessageManagerTest extends \PHPUnit_Framework_TestCase
      */
     protected function getMessageManagerMock()
     {
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
 
         $manager = new MessageManagerMock('Sonata\notificationBundle\Tests\Entity\Message', $registry);
 
@@ -170,29 +171,29 @@ class MessageManagerTest extends \PHPUnit_Framework_TestCase
         );
         $query->expects($this->any())->method('execute')->will($this->returnValue(true));
 
-        $qb = $this->getMock('Doctrine\ORM\QueryBuilder', array(), array(
-            $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock(),
-        ));
+        $qb = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
+            ->setConstructorArgs(array($this->createMock('Doctrine\ORM\EntityManager')))
+            ->getMock();
 
         $qb->expects($this->any())->method('select')->will($this->returnValue($qb));
         $qb->expects($this->any())->method('getQuery')->will($this->returnValue($query));
 
         $qbCallback($qb);
 
-        $repository = $this->getMockBuilder('Doctrine\ORM\EntityRepository')->disableOriginalConstructor()->getMock();
+        $repository = $this->createMock('Doctrine\ORM\EntityRepository');
         $repository->expects($this->any())->method('createQueryBuilder')->will($this->returnValue($qb));
 
-        $metadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
         $metadata->expects($this->any())->method('getFieldNames')->will($this->returnValue(array(
             'state',
             'type',
         )));
 
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $em = $this->createMock('Doctrine\ORM\EntityManager');
         $em->expects($this->any())->method('getRepository')->will($this->returnValue($repository));
         $em->expects($this->any())->method('getClassMetadata')->will($this->returnValue($metadata));
 
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
         return  new MessageManager('Sonata\NotificationBundle\Entity\BaseMessage', $registry);

--- a/Tests/Entity/MessageTest.php
+++ b/Tests/Entity/MessageTest.php
@@ -12,8 +12,9 @@
 namespace Sonata\NotificationBundle\Tests\Entity;
 
 use Sonata\NotificationBundle\Model\MessageInterface;
+use Sonata\NotificationBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class MessageTest extends \PHPUnit_Framework_TestCase
+class MessageTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider getBodyValues

--- a/Tests/Event/DoctrineOptimizeListenerTest.php
+++ b/Tests/Event/DoctrineOptimizeListenerTest.php
@@ -13,20 +13,19 @@ namespace Sonata\NotificationBundle\Tests\Entity;
 
 use Sonata\NotificationBundle\Event\DoctrineOptimizeListener;
 use Sonata\NotificationBundle\Event\IterateEvent;
+use Sonata\NotificationBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class DoctrineOptimizeListenerTest extends \PHPUnit_Framework_TestCase
+class DoctrineOptimizeListenerTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @expectedException \RuntimeException
      */
     public function testWithClosedManager()
     {
-        $manager = $this->getMockBuilder('Doctrine\ORM\EntityManager')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $manager = $this->createMock('Doctrine\ORM\EntityManager');
         $manager->expects($this->once())->method('isOpen')->will($this->returnValue(false));
 
-        $registry = $this->getMock('Symfony\Bridge\Doctrine\RegistryInterface');
+        $registry = $this->createMock('Symfony\Bridge\Doctrine\RegistryInterface');
         $registry->expects($this->once())->method('getManagers')->will($this->returnValue(array(
             'default' => $manager,
         )));
@@ -40,26 +39,22 @@ class DoctrineOptimizeListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testOptimize()
     {
-        $unitofwork = $this->getMockBuilder('Doctrine\ORM\UnitOfWork')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $unitofwork = $this->createMock('Doctrine\ORM\UnitOfWork');
         $unitofwork->expects($this->once())->method('clear');
 
-        $manager = $this->getMockBuilder('Doctrine\ORM\EntityManager')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $manager = $this->createMock('Doctrine\ORM\EntityManager');
         $manager->expects($this->once())->method('isOpen')->will($this->returnValue(true));
         $manager->expects($this->once())->method('getUnitOfWork')->will($this->returnValue($unitofwork));
 
-        $registry = $this->getMock('Symfony\Bridge\Doctrine\RegistryInterface');
+        $registry = $this->createMock('Symfony\Bridge\Doctrine\RegistryInterface');
         $registry->expects($this->once())->method('getManagers')->will($this->returnValue(array(
             'default' => $manager,
         )));
 
         $optimizer = new DoctrineOptimizeListener($registry);
         $optimizer->iterate(new IterateEvent(
-            $this->getMock('Sonata\NotificationBundle\Iterator\MessageIteratorInterface'),
-            $this->getMock('Sonata\NotificationBundle\Backend\BackendInterface')
+            $this->createMock('Sonata\NotificationBundle\Iterator\MessageIteratorInterface'),
+            $this->createMock('Sonata\NotificationBundle\Backend\BackendInterface')
         ));
     }
 }

--- a/Tests/Exception/InvalidParameterExceptionTest.php
+++ b/Tests/Exception/InvalidParameterExceptionTest.php
@@ -12,11 +12,12 @@
 namespace Sonata\NotificationBundle\Tests\Exception;
 
 use Sonata\NotificationBundle\Exception\InvalidParameterException;
+use Sonata\NotificationBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class InvalidParameterExceptionTest extends \PHPUnit_Framework_TestCase
+class InvalidParameterExceptionTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @expectedException \Sonata\NotificationBundle\Exception\InvalidParameterException

--- a/Tests/Helpers/PHPUnit_Framework_TestCase.php
+++ b/Tests/Helpers/PHPUnit_Framework_TestCase.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NotificationBundle\Tests\Helpers;
+
+/**
+ * This is helpers class for supporting old and new PHPUnit versions.
+ *
+ * @todo NEXT_MAJOR: Remove this class when dropping support for < PHPUnit 5.4.
+ *
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+class PHPUnit_Framework_TestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function expectException($exception, $message = '', $code = null)
+    {
+        if (is_callable('parent::expectException')) {
+            parent::expectException($exception);
+
+            if ($message !== '') {
+                parent::expectExceptionMessage($message);
+            }
+
+            if ($code !== null) {
+                parent::expectExceptionCode($code);
+            }
+        }
+
+        return parent::setExpectedException($exception, $message, $code);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createMock($originalClassName)
+    {
+        if (is_callable('parent::createMock')) {
+            return parent::createMock($originalClassName);
+        }
+
+        return parent::getMockBuilder($originalClassName)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->getMock();
+    }
+}

--- a/Tests/Iterator/IteratorProxyMessageIteratorTest.php
+++ b/Tests/Iterator/IteratorProxyMessageIteratorTest.php
@@ -12,11 +12,12 @@
 namespace Sonata\NotificationBundle\Tests\Iterator;
 
 use Sonata\NotificationBundle\Iterator\IteratorProxyMessageIterator;
+use Sonata\NotificationBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 /**
  * @covers \Sonata\NotificationBundle\Iterator\IteratorProxyMessageIterator
  */
-class IteratorProxyMessageIteratorTest extends \PHPUnit_Framework_TestCase
+class IteratorProxyMessageIteratorTest extends PHPUnit_Framework_TestCase
 {
     public function testIteratorProxiesIteratorMethods()
     {
@@ -25,7 +26,7 @@ class IteratorProxyMessageIteratorTest extends \PHPUnit_Framework_TestCase
             'bar',
         );
 
-        $actualIterator = $this->getMock('Iterator');
+        $actualIterator = $this->createMock('Iterator');
         $this->expectIterator($actualIterator, $content, true);
 
         $proxy = new IteratorProxyMessageIterator($actualIterator);

--- a/Tests/Iterator/MessageManagerMessageIteratorTest.php
+++ b/Tests/Iterator/MessageManagerMessageIteratorTest.php
@@ -11,14 +11,27 @@
 
 namespace Sonata\NotificationBundle\Tests\Iterator;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Sonata\NotificationBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
+
 /**
  * @author Kevin Nedelec <kevin.nedelec@ekino.com>
  */
-class MessageManagerMessageIteratorTest extends \PHPUnit_Framework_TestCase
+class MessageManagerMessageIteratorTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @var ManagerRegistry
+     */
+    private $registry;
+
+    protected function setUp()
+    {
+        $this->registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+    }
+
     public function testBufferize()
     {
-        $iterator = new MessageManagerMessageIterator($this->getRegistryMock(), 0);
+        $iterator = new MessageManagerMessageIterator($this->registry, 0);
 
         $iterator->_bufferize();
 
@@ -29,7 +42,7 @@ class MessageManagerMessageIteratorTest extends \PHPUnit_Framework_TestCase
     {
         $size = 10;
 
-        $iterator = new MessageManagerMessageIterator($this->getRegistryMock(), 0);
+        $iterator = new MessageManagerMessageIterator($this->registry, 0);
 
         $iterator->rewind();
         $this->assertTrue($iterator->valid());
@@ -50,7 +63,7 @@ class MessageManagerMessageIteratorTest extends \PHPUnit_Framework_TestCase
 
     public function testLongForeach()
     {
-        $iterator = new MessageManagerMessageIterator($this->getRegistryMock(), 500000, 2);
+        $iterator = new MessageManagerMessageIterator($this->registry, 500000, 2);
 
         $count = 0;
 
@@ -61,12 +74,5 @@ class MessageManagerMessageIteratorTest extends \PHPUnit_Framework_TestCase
                 return;
             }
         }
-    }
-
-    protected function getRegistryMock()
-    {
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
-
-        return $registry;
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.
