### PR TITLE
Add prefetch count configuration in AMQPBackend

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -223,6 +223,12 @@ Only used by RabbitMQ
 Defines the per-queue message time-to-live (milliseconds)
 EOF;
 
+        $prefetchCountInfo = <<<'EOF'
+Only used by RabbitMQ
+
+Defines the number of messages which will be delivered to the customer at a time.
+EOF;
+
         $typesInfo = <<<'EOF'
 Only used by Doctrine
 
@@ -267,6 +273,12 @@ EOF;
                 ->integerNode('ttl')
                     ->info($ttlInfo)
                     ->min(0)
+                    ->defaultValue(null)
+                ->end()
+                ->integerNode('prefetch_count')
+                    ->info($prefetchCountInfo)
+                    ->min(0)
+                    ->max(65535)
                     ->defaultValue(null)
                 ->end()
 

--- a/DependencyInjection/SonataNotificationExtension.php
+++ b/DependencyInjection/SonataNotificationExtension.php
@@ -335,6 +335,7 @@ class SonataNotificationExtension extends Extension
                 'dead_letter_exchange' => null,
                 'dead_letter_routing_key' => null,
                 'ttl' => null,
+                'prefetch_count' => null,
             ));
         }
 
@@ -381,7 +382,8 @@ class SonataNotificationExtension extends Extension
                 $queue['routing_key'],
                 $queue['dead_letter_exchange'],
                 $queue['dead_letter_routing_key'],
-                $queue['ttl']
+                $queue['ttl'],
+                $queue['prefetch_count']
             );
 
             $amqBackends[$pos] = array(
@@ -419,10 +421,11 @@ class SonataNotificationExtension extends Extension
      * @param string           $deadLetterExchange
      * @param string           $deadLetterRoutingKey
      * @param int|null         $ttl
+     * @param int|null         $prefetchCount
      *
      * @return string
      */
-    protected function createAMQPBackend(ContainerBuilder $container, $exchange, $name, $recover, $key = '', $deadLetterExchange = null, $deadLetterRoutingKey = null, $ttl = null)
+    protected function createAMQPBackend(ContainerBuilder $container, $exchange, $name, $recover, $key = '', $deadLetterExchange = null, $deadLetterRoutingKey = null, $ttl = null, $prefetchCount = null)
     {
         $id = 'sonata.notification.backend.rabbitmq.'.$this->amqpCounter++;
 
@@ -436,6 +439,7 @@ class SonataNotificationExtension extends Extension
                 $deadLetterExchange,
                 $deadLetterRoutingKey,
                 $ttl,
+                $prefetchCount,
             )
         );
         $definition->setPublic(false);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this change has no influence on current configurations/features,
only add the new feature.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #232

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added prefetch count configuration in AMQPBackend
```

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject

<!-- Describe your Pull Request content here -->
This enables to configure "prefetch_count" for the "Fair dispatch" in RabbitMQ.
reference: https://www.rabbitmq.com/tutorials/tutorial-two-php.html
