### PR TITLE
Drop old versions of php/sf

### DIFF
--- a/Admin/MessageAdmin.php
+++ b/Admin/MessageAdmin.php
@@ -16,6 +16,7 @@ use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\AdminBundle\Show\ShowMapper;
+use Sonata\DoctrineORMAdminBundle\Filter\ChoiceFilter;
 
 class MessageAdmin extends AbstractAdmin
 {
@@ -94,7 +95,7 @@ class MessageAdmin extends AbstractAdmin
 
         $datagridMapper
             ->add('type')
-            ->add('state', null, [], 'choice', ['choices' => $class::getStateList()])
+            ->add('state', null, [], ChoiceFilter::class, ['choices' => $class::getStateList()])
         ;
     }
 }


### PR DESCRIPTION
I am targeting this branch, because this is BC.

This is a followup for #263

## Changelog

```markdown
### Removed
- Support deprecations for old form alias usage
```
