### PR TITLE
Migrate to AMQP interop.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,4 @@ test:
 	phpunit -c phpunit.xml.dist --coverage-clover build/logs/clover.xml
 
 docs:
-	cd Resources/doc && sphinx-build -W -b html -d _build/doctrees . _build/html
+	cd docs && sphinx-build -W -b html -d _build/doctrees . _build/html

--- a/Tests/Iterator/AMQPMessageIteratorTest.php
+++ b/Tests/Iterator/AMQPMessageIteratorTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NotificationBundle\Tests\Iterator;
+
+use Interop\Amqp\AmqpConsumer;
+use Interop\Amqp\AmqpQueue;
+use Interop\Amqp\Impl\AmqpMessage;
+use PhpAmqpLib\Channel\AMQPChannel;
+use PHPUnit\Framework\TestCase;
+use Sonata\NotificationBundle\Iterator\AMQPMessageIterator;
+use Sonata\NotificationBundle\Iterator\MessageIteratorInterface;
+use Sonata\NotificationBundle\Model\Message;
+
+/**
+ * @covers \Sonata\NotificationBundle\Iterator\AMQPMessageIterator
+ */
+class AMQPMessageIteratorTest extends TestCase
+{
+    public function testShouldImplementMessageIteratorInterface()
+    {
+        $rc = new \ReflectionClass(AMQPMessageIterator::class);
+
+        $this->assertTrue($rc->implementsInterface(MessageIteratorInterface::class));
+    }
+
+    public function testCouldBeConstructedWithChannelAndContextAsArguments()
+    {
+        new AMQPMessageIterator($this->createChannelMock(), $this->createConsumerStub());
+    }
+
+    public function testShouldIterateOverThreeMessagesAndExit()
+    {
+        $firstMessage = new AmqpMessage('{"body": {"value": "theFirstMessageBody"}, "type": "aType", "state": "aState"}');
+        $secondMessage = new AmqpMessage('{"body": {"value": "theSecondMessageBody"}, "type": "aType", "state": "aState"}');
+        $thirdMessage = new AmqpMessage('{"body": {"value": "theThirdMessageBody"}, "type": "aType", "state": "aState"}');
+
+        $consumerMock = $this->createConsumerStub('aQueueName');
+        $consumerMock
+            ->expects($this->exactly(4))
+            ->method('receive')
+            ->willReturnOnConsecutiveCalls($firstMessage, $secondMessage, $thirdMessage, null);
+
+        $iterator = new AMQPMessageIterator($this->createChannelMock(), $consumerMock);
+
+        $values = [];
+        foreach ($iterator as $message) {
+            /* @var Message $message */
+
+            $this->assertInstanceOf(Message::class, $message);
+            $this->assertInstanceOf(\Interop\Amqp\AmqpMessage::class, $message->getValue('interopMessage'));
+            $this->assertInstanceOf(\PhpAmqpLib\Message\AMQPMessage::class, $message->getValue('AMQMessage'));
+
+            $values[] = $message->getValue('value');
+        }
+
+        $this->assertEquals(['theFirstMessageBody', 'theSecondMessageBody', 'theThirdMessageBody'], $values);
+    }
+
+    /**
+     * @param mixed $queueName
+     *
+     * @return AmqpConsumer|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createConsumerStub($queueName = null)
+    {
+        $queue = $this->createMock(AmqpQueue::class);
+        $queue
+            ->expects($this->any())
+            ->method('getQueueName')
+            ->willReturn($queueName)
+        ;
+
+        $consumer = $this->createMock(AmqpConsumer::class);
+        $consumer
+            ->expects($this->any())
+            ->method('getQueue')
+            ->willReturn($queue)
+        ;
+
+        return $consumer;
+    }
+
+    /**
+     * @return AMQPChannel|\PHPUnit_Framework_MockObject_MockObject|AMQPChannel
+     */
+    private function createChannelMock()
+    {
+        return $this->createMock(AMQPChannel::class);
+    }
+}

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,16 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.2 to 3.3
+=======================
+
+### AMQP
+
+You might face some issues (though we tried to keep everything BC) if you are extending `AMQPBackend`, `AMQPBackendDispatcher` or `AMQPMessageIterator` classes 
+or rely on their `__construct` method signature.
+
+If you want to migrate to another amqp interop compatible transport, say `enqueue/amqp-ext`, the BC layer want work and the exception is thrown.
+
 UPGRADE FROM 3.0 to 3.1
 =======================
 

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
+        "enqueue/amqp-lib": "^0.8",
         "symfony/config": "^2.8 || ^3.2",
         "symfony/console": "^2.8 || ^3.2",
         "symfony/dependency-injection": "^2.8 || ^3.2",
@@ -37,12 +38,11 @@
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
         "guzzlehttp/guzzle" : "If you want to get a status report when using the rabbitMQ backend.",
         "liip/monitor-bundle": "^1.0",
-        "php-amqplib/php-amqplib": "^2.0"
+        "queue-interop/amqp-interop": "Install any amqp-interop compatible transport if you want use RabbitMQ. For example enqueue/amqp-lib:^0.8"
     },
     "require-dev": {
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
         "guzzlehttp/guzzle" : "^3.8",
-        "php-amqplib/php-amqplib": "^2.0",
         "liip/monitor-bundle": "^2.0",
         "symfony/phpunit-bridge": "^3.3",
         "swiftmailer/swiftmailer": "^4.3 || ^5.0",

--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -80,6 +80,7 @@ Full configuration options:
                         pass:                 guest
                         vhost:                guest
                         console_url:          'http://localhost:55672/api'
+                        factory_class:        \Enqueue\AmqpLib\AmqpConnectionFactory
             consumers:
 
                 # If set to true, SwiftMailerConsumer and LoggerConsumer will be registered as services
@@ -108,3 +109,35 @@ Full configuration options:
                         mappings:
                             SonataNotificationBundle: ~
                             ApplicationSonataNotificationBundle: ~
+
+
+Changing AMQP transport
+-----------------------
+
+Sonata integrates with `queue interop`_ and by default uses `enqueue/amqp-lib`_.
+Though you can pick your favorite library among:
+
+* `enqueue/amqp-ext`_: use `Enqueue\AmqpExt\AmqpConnectionFactory` class.
+* `enqueue/amqp-lib`_: use `Enqueue\AmqpLib\AmqpConnectionFactory` class.
+* `enqueue/amqp-bunny`_: use `Enqueue\AmqpBunny\AmqpConnectionFactory` class.
+
+For example if you decide to use `enqueue/amqp-bunny`_ transport,
+run `composer require enqueue/amqp-ext:^0.8` and change `factory_class` option in the config:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        sonata_notification:
+            backends:
+                rabbitmq:
+                    connection:
+                        factory_class:        \Enqueue\AmqpExt\AmqpConnectionFactory
+
+
+
+.. _`queue interop`: https://github.com/queue-interop/queue-interop#amqp-interop
+.. _`enqueue/amqp-lib`: https://github.com/php-enqueue/enqueue-dev/blob/master/docs/transport/amqp_lib.md
+.. _`enqueue/amqp-ext`: https://github.com/php-enqueue/enqueue-dev/blob/master/docs/transport/amqp_ext.md
+.. _`enqueue/amqp-bunny`: https://github.com/php-enqueue/enqueue-dev/blob/master/docs/transport/amqp_bunny.md
+

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -6,7 +6,7 @@ To begin, add the dependent bundles:
 .. code-block:: bash
 
     php composer.phar require sonata-project/notification-bundle
-    php composer.phar require php-amqplib/php-amqplib --no-update # optional
+    php composer.phar require enqueue/amqp-lib --no-update # optional
     php composer.phar require liip/monitor-bundle --no-update     # optional
     php composer.phar require friendsofsymfony/rest-bundle  --no-update # optional when using api
     php composer.phar require nelmio/api-doc-bundle  --no-update # optional when using api

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\NotificationBundle\DependencyInjection;
 
+use Enqueue\AmqpLib\AmqpConnectionFactory;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -112,6 +113,12 @@ EOF;
                                     ->end()
                                     ->scalarNode('console_url')
                                         ->defaultValue('http://localhost:55672/api')
+                                    ->end()
+                                    ->scalarNode('factory_class')
+                                        ->cannotBeEmpty()
+                                        ->isRequired()
+                                        ->defaultValue(AmqpConnectionFactory::class)
+                                        ->info('This option defines an AMQP connection factory to be used to establish a connection with RabbitMQ.')
                                     ->end()
                                 ->end()
                             ->end()

--- a/tests/Mock/AmqpConnectionFactoryStub.php
+++ b/tests/Mock/AmqpConnectionFactoryStub.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NotificationBundle\Tests\Mock;
+
+use Interop\Amqp\AmqpConnectionFactory;
+use Interop\Queue\PsrContext;
+
+class AmqpConnectionFactoryStub implements AmqpConnectionFactory
+{
+    public static $config;
+    public static $context;
+
+    public function __construct($config)
+    {
+        static::$config = $config;
+    }
+
+    /**
+     * @return PsrContext
+     */
+    public function createContext()
+    {
+        return static::$context;
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it contains BC breaks.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataNotificationBundle/issues/275

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- The [php-amqplib](https://github.com/php-amqplib/php-amqplib) is replaced with [enqueue/amqp-lib](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/transport/amqp_lib.md). This is BC change cuz it still uses php-amqplib internally. The change adopts [amqp interop](https://github.com/queue-interop/queue-interop#amqp-interop) standard which allows decouple the bundle from php-amqplib and use other its implementations in future. 
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Changelog
- [x] Update the tests
- [x] Update the documentation
- [x] Add an upgrade note

## Subject

The PR replaces [php-amqplib](https://github.com/php-amqplib/php-amqplib) usage with the solution based on [AMQP interop](https://github.com/queue-interop/queue-interop#amqp-interop). There are several reasons for that:

* The code does not rely on an implementation but interoperable interfaces. 
* The biggest advantage among others is that it would work with not only php-amqplib but amqp-ext, and bunny, or any amqp interop compatible libraries.
* cleaner OO API.
* less code, fewer bugs.
* no need for dealing with low-level details ( the right type for queue argument).
* supports delaying out of the box
* supports secure connections. 


