### PR TITLE
Amqp remove deprecations

### DIFF
--- a/Tests/Iterator/AMQPMessageIteratorTest.php
+++ b/Tests/Iterator/AMQPMessageIteratorTest.php
@@ -12,9 +12,7 @@
 namespace Sonata\NotificationBundle\Tests\Iterator;
 
 use Interop\Amqp\AmqpConsumer;
-use Interop\Amqp\AmqpQueue;
 use Interop\Amqp\Impl\AmqpMessage;
-use PhpAmqpLib\Channel\AMQPChannel;
 use PHPUnit\Framework\TestCase;
 use Sonata\NotificationBundle\Iterator\AMQPMessageIterator;
 use Sonata\NotificationBundle\Iterator\MessageIteratorInterface;
@@ -32,9 +30,9 @@ class AMQPMessageIteratorTest extends TestCase
         $this->assertTrue($rc->implementsInterface(MessageIteratorInterface::class));
     }
 
-    public function testCouldBeConstructedWithChannelAndContextAsArguments()
+    public function testCouldBeConstructedWithContextAsFirstArgument()
     {
-        new AMQPMessageIterator($this->createChannelMock(), $this->createConsumerStub());
+        new AMQPMessageIterator($this->createMock(AmqpConsumer::class));
     }
 
     public function testShouldIterateOverThreeMessagesAndExit()
@@ -43,13 +41,13 @@ class AMQPMessageIteratorTest extends TestCase
         $secondMessage = new AmqpMessage('{"body": {"value": "theSecondMessageBody"}, "type": "aType", "state": "aState"}');
         $thirdMessage = new AmqpMessage('{"body": {"value": "theThirdMessageBody"}, "type": "aType", "state": "aState"}');
 
-        $consumerMock = $this->createConsumerStub('aQueueName');
+        $consumerMock = $this->createMock(AmqpConsumer::class);
         $consumerMock
             ->expects($this->exactly(4))
             ->method('receive')
             ->willReturnOnConsecutiveCalls($firstMessage, $secondMessage, $thirdMessage, null);
 
-        $iterator = new AMQPMessageIterator($this->createChannelMock(), $consumerMock);
+        $iterator = new AMQPMessageIterator($consumerMock);
 
         $values = [];
         foreach ($iterator as $message) {
@@ -57,43 +55,10 @@ class AMQPMessageIteratorTest extends TestCase
 
             $this->assertInstanceOf(Message::class, $message);
             $this->assertInstanceOf(\Interop\Amqp\AmqpMessage::class, $message->getValue('interopMessage'));
-            $this->assertInstanceOf(\PhpAmqpLib\Message\AMQPMessage::class, $message->getValue('AMQMessage'));
 
             $values[] = $message->getValue('value');
         }
 
         $this->assertEquals(['theFirstMessageBody', 'theSecondMessageBody', 'theThirdMessageBody'], $values);
-    }
-
-    /**
-     * @param mixed $queueName
-     *
-     * @return AmqpConsumer|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private function createConsumerStub($queueName = null)
-    {
-        $queue = $this->createMock(AmqpQueue::class);
-        $queue
-            ->expects($this->any())
-            ->method('getQueueName')
-            ->willReturn($queueName)
-        ;
-
-        $consumer = $this->createMock(AmqpConsumer::class);
-        $consumer
-            ->expects($this->any())
-            ->method('getQueue')
-            ->willReturn($queue)
-        ;
-
-        return $consumer;
-    }
-
-    /**
-     * @return AMQPChannel|\PHPUnit_Framework_MockObject_MockObject|AMQPChannel
-     */
-    private function createChannelMock()
-    {
-        return $this->createMock(AMQPChannel::class);
     }
 }

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -4,7 +4,7 @@ UPGRADE FROM 3.x to 4.0
 ### Closed API
 
 * `AMQPBackendDispatcher` and `AMQPMessageIterator` classes are final. You cannot extend them.
-* `AMQPBackend` properties are private now. You cannot overwrite them.
+* `AMQPBackend` properties are private now.
 
 ### AMQP
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -1,6 +1,11 @@
 UPGRADE FROM 3.x to 4.0
 =======================
 
+### Closed API
+
+* `AMQPBackendDispatcher` and `AMQPMessageIterator` classes are final. You cannot extend them.
+* `AMQPBackend` properties are private now. You cannot overwrite them.
+
 ### AMQP
 
 * `AMQPBackendDispatcher::channel` property was removed. Consider removing dependency on it or use `AMQPBackendDispatcher::getContext()` method.

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -1,2 +1,16 @@
-UPGRADE FROM 2.x to 4.0
+UPGRADE FROM 3.x to 4.0
 =======================
+
+### AMQP
+
+* `AMQPBackendDispatcher::channel` property was removed. Consider removing dependency on it or use `AMQPBackendDispatcher::getContext()` method.
+*  `AMQPBackendDispatcher::connection` property was removed. Consider removing dependency it.
+*  `AMQPBackendDispatcher::getChannel()` method was removed. Consider removing dependency on it or use `AMQPBackendDispatcher::getContext()` method.
+* The first constructor of `AMQPMessageIterator` constructor was removed.
+* `AMQPMessageIterator::queue` property was removed. Consider removing dependency on it.
+* `AMQPMessageIterator::AMQMessage` property was removed. Consider removing dependency on it or use `Sonata\NotificationBundle\Model\Message::getValue('interopMessage')`.
+* `Sonata\NotificationBundle\Model\Message::getValue('AMQMessage')` is not available any more. Consider removing dependency on it or use `Sonata\NotificationBundle\Model\Message::getValue('interopMessage')`.
+*  `AMQPBackend::getChannel()` method was removed. Consider removing dependency on it or use `AMQPBackend::getContext()` method.
+
+
+

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -11,6 +11,3 @@ UPGRADE FROM 3.x to 4.0
 * `AMQPMessageIterator::AMQMessage` property was removed. Consider removing dependency on it or use `Sonata\NotificationBundle\Model\Message::getValue('interopMessage')`.
 * `Sonata\NotificationBundle\Model\Message::getValue('AMQMessage')` is not available any more. Consider removing dependency on it or use `Sonata\NotificationBundle\Model\Message::getValue('interopMessage')`.
 *  `AMQPBackend::getChannel()` method was removed. Consider removing dependency on it or use `AMQPBackend::getContext()` method.
-
-
-

--- a/src/Backend/AMQPBackend.php
+++ b/src/Backend/AMQPBackend.php
@@ -34,42 +34,42 @@ class AMQPBackend implements BackendInterface
     /**
      * @var AMQPBackendDispatcher
      */
-    protected $dispatcher = null;
+    private $dispatcher = null;
 
     /**
      * @var string
      */
-    protected $exchange;
+    private $exchange;
 
     /**
      * @var string
      */
-    protected $queue;
+    private $queue;
 
     /**
      * @var string
      */
-    protected $key;
+    private $key;
 
     /**
      * @var string
      */
-    protected $recover;
+    private $recover;
 
     /**
      * @var null|string
      */
-    protected $deadLetterExchange;
+    private $deadLetterExchange;
 
     /**
      * @var null|string
      */
-    protected $deadLetterRoutingKey;
+    private $deadLetterRoutingKey;
 
     /**
      * @var null|int
      */
-    protected $ttl;
+    private $ttl;
 
     /**
      * @var null|int

--- a/src/Backend/AMQPBackend.php
+++ b/src/Backend/AMQPBackend.php
@@ -17,7 +17,6 @@ use Interop\Amqp\AmqpMessage;
 use Interop\Amqp\AmqpQueue;
 use Interop\Amqp\AmqpTopic;
 use Interop\Amqp\Impl\AmqpBind;
-use PhpAmqpLib\Channel\AMQPChannel;
 use Sonata\NotificationBundle\Consumer\ConsumerEvent;
 use Sonata\NotificationBundle\Exception\HandlingException;
 use Sonata\NotificationBundle\Iterator\AMQPMessageIterator;
@@ -209,7 +208,7 @@ class AMQPBackend implements BackendInterface
         $this->consumer = $this->getContext()->createConsumer($this->getContext()->createQueue($this->queue));
         $this->consumer->setConsumerTag('sonata_notification_'.uniqid());
 
-        return new AMQPMessageIterator($this->getChannel(), $this->consumer);
+        return new AMQPMessageIterator($this->consumer);
     }
 
     /**
@@ -266,20 +265,6 @@ class AMQPBackend implements BackendInterface
     public function cleanup()
     {
         throw new \RuntimeException('Not implemented');
-    }
-
-    /**
-     * @deprecated since 3.2, will be removed in 4.x
-     *
-     * @return AMQPChannel
-     */
-    protected function getChannel()
-    {
-        if (null === $this->dispatcher) {
-            throw new \RuntimeException('Unable to retrieve AMQP channel without dispatcher.');
-        }
-
-        return $this->dispatcher->getChannel();
     }
 
     /**

--- a/src/Backend/AMQPBackendDispatcher.php
+++ b/src/Backend/AMQPBackendDispatcher.php
@@ -16,8 +16,6 @@ use Enqueue\AmqpTools\RabbitMqDlxDelayStrategy;
 use Guzzle\Http\Client as GuzzleClient;
 use Interop\Amqp\AmqpConnectionFactory;
 use Interop\Amqp\AmqpContext;
-use PhpAmqpLib\Channel\AMQPChannel;
-use PhpAmqpLib\Connection\AMQPConnection;
 use Sonata\NotificationBundle\Exception\BackendNotFoundException;
 use Sonata\NotificationBundle\Model\MessageInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -33,20 +31,6 @@ class AMQPBackendDispatcher extends QueueBackendDispatcher
      * @var array
      */
     protected $settings;
-
-    /**
-     * @deprecated since 3.2, will be removed in 4.x
-     *
-     * @var AMQPChannel
-     */
-    protected $channel;
-
-    /**
-     * @deprecated since 3.2, will be removed in 4.x
-     *
-     * @var AMQPConnection
-     */
-    protected $connection;
 
     protected $backendsInitialized = false;
 
@@ -71,33 +55,6 @@ class AMQPBackendDispatcher extends QueueBackendDispatcher
         parent::__construct($queues, $defaultQueue, $backends);
 
         $this->settings = $settings;
-    }
-
-    /**
-     * @deprecated since 3.2, will be removed in 4.x
-     *
-     * @return AMQPChannel
-     */
-    public function getChannel()
-    {
-        @trigger_error(sprintf('The method %s is deprecated since version 3.3 and will be removed in 4.0. Use %s::getContext() instead.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
-
-        if (!$this->channel) {
-            if (!$this->context instanceof \Enqueue\AmqpLib\AmqpContext) {
-                throw new \LogicException('The BC layer works only if enqueue/amqp-lib lib is being used.');
-            }
-
-            // load context
-            $this->getContext();
-
-            /** @var \Enqueue\AmqpLib\AmqpContext $context */
-            $context = $this->getContext();
-
-            $this->channel = $context->getLibChannel();
-            $this->connection = $this->channel->getConnection();
-        }
-
-        return $this->channel;
     }
 
     /**

--- a/src/Backend/AMQPBackendDispatcher.php
+++ b/src/Backend/AMQPBackendDispatcher.php
@@ -25,14 +25,14 @@ use ZendDiagnostics\Result\Success;
 /**
  * Producer side of the rabbitmq backend.
  */
-class AMQPBackendDispatcher extends QueueBackendDispatcher
+final class AMQPBackendDispatcher extends QueueBackendDispatcher
 {
     /**
      * @var array
      */
-    protected $settings;
+    private $settings;
 
-    protected $backendsInitialized = false;
+    private $backendsInitialized = false;
 
     /**
      * @var AmqpConnectionFactory
@@ -60,7 +60,7 @@ class AMQPBackendDispatcher extends QueueBackendDispatcher
     /**
      * @return AmqpContext
      */
-    final public function getContext()
+    public function getContext()
     {
         if (!$this->context) {
             if (!array_key_exists('factory_class', $this->settings)) {

--- a/src/Iterator/AMQPMessageIterator.php
+++ b/src/Iterator/AMQPMessageIterator.php
@@ -14,17 +14,17 @@ namespace Sonata\NotificationBundle\Iterator;
 use Interop\Amqp\AmqpConsumer;
 use Sonata\NotificationBundle\Model\Message;
 
-class AMQPMessageIterator implements MessageIteratorInterface
+final class AMQPMessageIterator implements MessageIteratorInterface
 {
     /**
      * @var mixed
      */
-    protected $message;
+    private $message;
 
     /**
      * @var int
      */
-    protected $counter;
+    private $counter;
 
     /**
      * @var int

--- a/tests/Backend/AMQPBackendTest.php
+++ b/tests/Backend/AMQPBackendTest.php
@@ -242,9 +242,6 @@ class AMQPBackendTest extends TestCase
         $queue = new ImplAmqpQueue('aQueue');
 
         $consumerMock = $this->createMock(AmqpConsumer::class);
-        $consumerMock->expects($this->once())
-            ->method('getQueue')
-            ->willReturn($queue);
 
         $contextMock = $this->createMock(AmqpContext::class);
         $contextMock->expects($this->never())
@@ -272,9 +269,6 @@ class AMQPBackendTest extends TestCase
 
         $queue = new ImplAmqpQueue('aQueue');
         $consumerMock = $this->createMock(AmqpConsumer::class);
-        $consumerMock->expects($this->once())
-            ->method('getQueue')
-            ->willReturn($queue);
 
         $contextMock = $this->createMock(AmqpContext::class);
         $contextMock->expects($this->once())
@@ -326,16 +320,12 @@ class AMQPBackendTest extends TestCase
             ['queue' => self::QUEUE, 'routing_key' => self::KEY],
         ];
 
-        $dispatcherMock = $this->getMockBuilder(AMQPBackendDispatcher::class)
-            ->setConstructorArgs([$settings, $queues, 'default', [['type' => self::KEY, 'backend' => $backend]]])
-            ->setMethods(['getChannel'])
-            ->getMock();
-
-        $dispatcherMock
-            ->expects($this->any())
-            ->method('getChannel')
-            ->willReturn($this->createMock(AMQPChannel::class))
-        ;
+        $dispatcherMock = new AMQPBackendDispatcher(
+            $settings,
+            $queues,
+            'default',
+            [['type' => self::KEY, 'backend' => $backend]]
+        );
 
         $backend->setDispatcher($dispatcherMock);
 

--- a/tests/Backend/AMQPBackendTest.php
+++ b/tests/Backend/AMQPBackendTest.php
@@ -20,7 +20,6 @@ use Interop\Amqp\AmqpTopic;
 use Interop\Amqp\Impl\AmqpBind as ImplAmqpBind;
 use Interop\Amqp\Impl\AmqpQueue as ImplAmqpQueue;
 use Interop\Amqp\Impl\AmqpTopic as ImplAmqpTopic;
-use PhpAmqpLib\Channel\AMQPChannel;
 use PHPUnit\Framework\TestCase;
 use Sonata\NotificationBundle\Backend\AMQPBackend;
 use Sonata\NotificationBundle\Backend\AMQPBackendDispatcher;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because there is a BC-break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Follow up https://github.com/sonata-project/SonataNotificationBundle/pull/276

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- The pull request removes previously deprecated stuff from the PR [#276](https://github.com/sonata-project/SonataNotificationBundle/pull/276). Now AMQP implementation relies on amqp interop and no longer coupled to php-amqplib. 
```

## Subject

The pull request remove previously deprecated stuff from the PR: https://github.com/sonata-project/SonataNotificationBundle/pull/276
