### PR TITLE
Restore PHP 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.1",
         "enqueue/amqp-lib": "^0.8",
         "sonata-project/core-bundle": "^3.0",
         "sonata-project/datagrid-bundle": "^2.2.1",


### PR DESCRIPTION
After the back and forth of PHP versions, we lost 7.1 on master, which was not intended. This PR restores it.