### PR TITLE
Use ChoiceType instead of ChoiceFilter

### DIFF
--- a/src/Admin/MessageAdmin.php
+++ b/src/Admin/MessageAdmin.php
@@ -16,7 +16,7 @@ use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\AdminBundle\Show\ShowMapper;
-use Sonata\DoctrineORMAdminBundle\Filter\ChoiceFilter;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
 class MessageAdmin extends AbstractAdmin
 {
@@ -95,7 +95,7 @@ class MessageAdmin extends AbstractAdmin
 
         $datagridMapper
             ->add('type')
-            ->add('state', null, [], ChoiceFilter::class, ['choices' => $class::getStateList()])
+            ->add('state', null, [], ChoiceType::class, ['choices' => $class::getStateList()])
         ;
     }
 }


### PR DESCRIPTION
I am targeting this branch, because i've found a bug in the 3.x branch.

## Changelog

```markdown
### Fixed
- MessageAdmin loads correct ChoiceType for the state filter (instead of ChoiceFilter)
```

## Subject

![exception screenshot](https://screenshots.firefoxusercontent.com/images/48fcdafd-12cd-42bf-a5d7-dbfe50b8da93.png "")
