### PR TITLE
Autoregister consumer as public service

### DIFF
--- a/src/DependencyInjection/Compiler/NotificationCompilerPass.php
+++ b/src/DependencyInjection/Compiler/NotificationCompilerPass.php
@@ -34,6 +34,9 @@ class NotificationCompilerPass implements CompilerPassInterface
         $informations = [];
 
         foreach ($container->findTaggedServiceIds('sonata.notification.consumer') as $id => $events) {
+            $definition = $container->getDefinition($id);
+            $definition->setPublic(true);
+
             foreach ($events as $event) {
                 $priority = isset($event['priority']) ? $event['priority'] : 0;
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
 - Autoregister consumer as public service
```

## Subject

This patch is needed for sf 4.