### PR TITLE
Replace FQCN strings with ::class constants

### DIFF
--- a/src/Controller/Api/MessageController.php
+++ b/src/Controller/Api/MessageController.php
@@ -145,7 +145,7 @@ class MessageController
 
             $view = FOSRestView::create($message);
 
-            if (class_exists('FOS\RestBundle\Context\Context')) {
+            if (class_exists(Context::class)) {
                 $serializationContext = new Context();
                 if (method_exists($serializationContext, 'enableMaxDepth')) {
                     $serializationContext->enableMaxDepth();

--- a/src/DependencyInjection/Compiler/NotificationCompilerPass.php
+++ b/src/DependencyInjection/Compiler/NotificationCompilerPass.php
@@ -12,6 +12,7 @@
 namespace Sonata\NotificationBundle\DependencyInjection\Compiler;
 
 use Sonata\NotificationBundle\Event\IterateEvent;
+use Sonata\NotificationBundle\Event\IterationListener;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -56,7 +57,7 @@ class NotificationCompilerPass implements CompilerPassInterface
                 /*
                  * NEXT_MAJOR: Remove check for ServiceClosureArgument and the addListenerService method call.
                  */
-                if (class_exists('Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument')) {
+                if (class_exists(ServiceClosureArgument::class)) {
                     $definition->addMethodCall(
                         'addListener',
                         [
@@ -87,7 +88,7 @@ class NotificationCompilerPass implements CompilerPassInterface
                 $definition = $container->getDefinition($serviceId);
 
                 $class = new \ReflectionClass($definition->getClass());
-                if (!$class->implementsInterface('Sonata\NotificationBundle\Event\IterationListener')) {
+                if (!$class->implementsInterface(IterationListener::class)) {
                     throw new RuntimeException(
                         'Iteration listeners must implement Sonata\NotificationBundle\Event\IterationListener'
                     );

--- a/src/DependencyInjection/SonataNotificationExtension.php
+++ b/src/DependencyInjection/SonataNotificationExtension.php
@@ -12,8 +12,11 @@
 namespace Sonata\NotificationBundle\DependencyInjection;
 
 use Sonata\EasyExtendsBundle\Mapper\DoctrineCollector;
+use Sonata\NotificationBundle\Backend\AMQPBackend;
+use Sonata\NotificationBundle\Backend\MessageManagerBackend;
 use Sonata\NotificationBundle\Model\MessageInterface;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader;
@@ -40,7 +43,7 @@ class SonataNotificationExtension extends Extension
         /*
          * NEXT_MAJOR: Remove the check for ServiceClosureArgument as well as core_legacy.xml.
          */
-        if (class_exists('Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument')) {
+        if (class_exists(ServiceClosureArgument::class)) {
             $loader->load('core.xml');
         } else {
             $loader->load('core_legacy.xml');
@@ -307,7 +310,7 @@ class SonataNotificationExtension extends Extension
             $id = 'sonata.notification.backend.doctrine.'.$key;
         }
 
-        $definition = new Definition('Sonata\NotificationBundle\Backend\MessageManagerBackend', [$manager, $checkLevel, $pause, $maxAge, $batchSize, $types]);
+        $definition = new Definition(MessageManagerBackend::class, [$manager, $checkLevel, $pause, $maxAge, $batchSize, $types]);
         $definition->setPublic(false);
 
         $container->setDefinition($id, $definition);
@@ -430,7 +433,7 @@ class SonataNotificationExtension extends Extension
         $id = 'sonata.notification.backend.rabbitmq.'.$this->amqpCounter++;
 
         $definition = new Definition(
-            'Sonata\NotificationBundle\Backend\AMQPBackend',
+            AMQPBackend::class,
             [
                 $exchange,
                 $name,

--- a/src/SonataNotificationBundle.php
+++ b/src/SonataNotificationBundle.php
@@ -13,6 +13,7 @@ namespace Sonata\NotificationBundle;
 
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\NotificationBundle\DependencyInjection\Compiler\NotificationCompilerPass;
+use Sonata\NotificationBundle\Form\Type\MessageSerializationType;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -47,7 +48,7 @@ class SonataNotificationBundle extends Bundle
     public function registerFormMapping()
     {
         FormHelper::registerFormTypeMapping([
-            'sonata_notification_api_form_message' => 'Sonata\NotificationBundle\Form\Type\MessageSerializationType',
+            'sonata_notification_api_form_message' => MessageSerializationType::class,
         ]);
     }
 }

--- a/tests/Backend/AMQPBackendDispatcherTest.php
+++ b/tests/Backend/AMQPBackendDispatcherTest.php
@@ -15,6 +15,7 @@ use Enqueue\AmqpLib\AmqpConnectionFactory;
 use Interop\Amqp\AmqpContext;
 use MyProject\Proxies\__CG__\stdClass;
 use PHPUnit\Framework\TestCase;
+use Sonata\NotificationBundle\Backend\AMQPBackend;
 use Sonata\NotificationBundle\Backend\AMQPBackendDispatcher;
 use Sonata\NotificationBundle\Exception\BackendNotFoundException;
 use Sonata\NotificationBundle\Tests\Mock\AmqpConnectionFactoryStub;
@@ -178,7 +179,7 @@ class AMQPBackendDispatcherTest extends TestCase
     {
         $methods = ['createAndPublish', 'initialize'];
         $args = ['', 'foo', false, 'message.type.foo'];
-        $mock = $this->getMockBuilder('Sonata\NotificationBundle\Backend\AMQPBackend')
+        $mock = $this->getMockBuilder(AMQPBackend::class)
                      ->setConstructorArgs($args)
                      ->setMethods($methods)
                      ->getMock();

--- a/tests/Backend/BackendHealthCheckTest.php
+++ b/tests/Backend/BackendHealthCheckTest.php
@@ -13,13 +13,14 @@ namespace Sonata\NotificationBundle\Tests\Notification;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\NotificationBundle\Backend\BackendHealthCheck;
+use Sonata\NotificationBundle\Backend\BackendInterface;
 use ZendDiagnostics\Result\Success;
 
 class BackendHealthCheckTest extends TestCase
 {
     public function setUp()
     {
-        if (!class_exists('ZendDiagnostics\Result\Success')) {
+        if (!class_exists(Success::class)) {
             $this->markTestSkipped('ZendDiagnostics\Result\Success does not exist');
         }
     }
@@ -28,7 +29,7 @@ class BackendHealthCheckTest extends TestCase
     {
         $result = new Success('Test check', 'OK');
 
-        $backend = $this->createMock('Sonata\NotificationBundle\Backend\BackendInterface');
+        $backend = $this->createMock(BackendInterface::class);
         $backend->expects($this->once())->method('getStatus')->will($this->returnValue($result));
 
         $health = new BackendHealthCheck($backend);

--- a/tests/Backend/MessageManagerBackendDispatcherTest.php
+++ b/tests/Backend/MessageManagerBackendDispatcherTest.php
@@ -12,8 +12,10 @@
 namespace Sonata\NotificationBundle\Tests\Backend;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\NotificationBundle\Backend\MessageManagerBackend;
 use Sonata\NotificationBundle\Backend\MessageManagerBackendDispatcher;
 use Sonata\NotificationBundle\Model\Message;
+use Sonata\NotificationBundle\Model\MessageManagerInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -22,7 +24,7 @@ class MessageManagerBackendDispatcherTest extends TestCase
 {
     public function testCreate()
     {
-        $testBackend = $this->createMock('Sonata\NotificationBundle\Backend\MessageManagerBackend');
+        $testBackend = $this->createMock(MessageManagerBackend::class);
 
         $testBackend->expects($this->once())
             ->method('setDispatcher')
@@ -37,7 +39,7 @@ class MessageManagerBackendDispatcherTest extends TestCase
             ->will($this->returnValue($message))
         ;
 
-        $mMgr = $this->createMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
+        $mMgr = $this->createMock(MessageManagerInterface::class);
 
         $mMgrBackend = new MessageManagerBackendDispatcher($mMgr, [], '', [['types' => ['test'], 'backend' => $testBackend]]);
 

--- a/tests/Backend/MessageManagerBackendTest.php
+++ b/tests/Backend/MessageManagerBackendTest.php
@@ -15,7 +15,9 @@ use PHPUnit\Framework\TestCase;
 use Sonata\NotificationBundle\Backend\MessageManagerBackend;
 use Sonata\NotificationBundle\Exception\HandlingException;
 use Sonata\NotificationBundle\Model\MessageInterface;
+use Sonata\NotificationBundle\Model\MessageManagerInterface;
 use Sonata\NotificationBundle\Tests\Entity\Message;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use ZendDiagnostics\Result\Failure;
 use ZendDiagnostics\Result\Success;
 use ZendDiagnostics\Result\Warning;
@@ -25,14 +27,14 @@ class MessageManagerBackendTest extends TestCase
     public function testCreateAndPublish()
     {
         $message = new Message();
-        $modelManager = $this->createMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
+        $modelManager = $this->createMock(MessageManagerInterface::class);
         $modelManager->expects($this->once())->method('save')->will($this->returnValue($message));
         $modelManager->expects($this->once())->method('create')->will($this->returnValue($message));
 
         $backend = new MessageManagerBackend($modelManager, []);
         $message = $backend->createAndPublish('foo', ['message' => 'salut']);
 
-        $this->assertInstanceOf('Sonata\\NotificationBundle\\Model\\MessageInterface', $message);
+        $this->assertInstanceOf(MessageInterface::class, $message);
         $this->assertEquals(MessageInterface::STATE_OPEN, $message->getState());
         $this->assertNotNull($message->getCreatedAt());
         $this->assertEquals('foo', $message->getType());
@@ -42,10 +44,10 @@ class MessageManagerBackendTest extends TestCase
     public function testHandleSuccess()
     {
         $message = new Message();
-        $modelManager = $this->createMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
+        $modelManager = $this->createMock(MessageManagerInterface::class);
         $modelManager->expects($this->exactly(2))->method('save')->will($this->returnValue($message));
 
-        $dispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
         $dispatcher->expects($this->once())->method('dispatch');
 
         $backend = new MessageManagerBackend($modelManager, []);
@@ -60,10 +62,10 @@ class MessageManagerBackendTest extends TestCase
     public function testHandleError()
     {
         $message = new Message();
-        $modelManager = $this->createMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
+        $modelManager = $this->createMock(MessageManagerInterface::class);
         $modelManager->expects($this->exactly(2))->method('save')->will($this->returnValue($message));
 
-        $dispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
         $dispatcher->expects($this->once())->method('dispatch')->will($this->throwException(new \RuntimeException()));
         $backend = new MessageManagerBackend($modelManager, []);
 
@@ -74,7 +76,7 @@ class MessageManagerBackendTest extends TestCase
         } catch (HandlingException $e) {
         }
 
-        $this->assertInstanceOf('Sonata\NotificationBundle\Exception\HandlingException', $e);
+        $this->assertInstanceOf(HandlingException::class, $e);
 
         $this->assertEquals(MessageInterface::STATE_ERROR, $message->getState());
         $this->assertNotNull($message->getCreatedAt());
@@ -86,11 +88,11 @@ class MessageManagerBackendTest extends TestCase
      */
     public function testStatus($counts, $expectedStatus, $message)
     {
-        if (!class_exists('ZendDiagnostics\Result\Success')) {
+        if (!class_exists(Success::class)) {
             $this->markTestSkipped('The class ZendDiagnostics\Result\Success does not exist');
         }
 
-        $modelManager = $this->createMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
+        $modelManager = $this->createMock(MessageManagerInterface::class);
         $modelManager->expects($this->exactly(1))->method('countStates')->will($this->returnValue($counts));
 
         $backend = new MessageManagerBackend($modelManager, [
@@ -108,7 +110,7 @@ class MessageManagerBackendTest extends TestCase
 
     public static function statusProvider()
     {
-        if (!class_exists('ZendDiagnostics\Result\Success')) {
+        if (!class_exists(Success::class)) {
             return [[1, 1, 1]];
         }
 

--- a/tests/Backend/PostponeRuntimeBackendTest.php
+++ b/tests/Backend/PostponeRuntimeBackendTest.php
@@ -16,6 +16,8 @@ use Sonata\NotificationBundle\Backend\PostponeRuntimeBackend;
 use Sonata\NotificationBundle\Consumer\ConsumerEventInterface;
 use Sonata\NotificationBundle\Model\MessageInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use ZendDiagnostics\Result\Success;
 
 /**
  * @covers \Sonata\NotificationBundle\Backend\PostponeRuntimeBackend
@@ -25,7 +27,7 @@ class PostponeRuntimeBackendTest extends TestCase
     public function testIteratorContainsPublishedMessages()
     {
         $backend = new PostponeRuntimeBackend(
-            $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface'),
+            $this->createMock(EventDispatcherInterface::class),
             true
         );
 
@@ -53,9 +55,9 @@ class PostponeRuntimeBackendTest extends TestCase
 
     public function testNoMessagesOnEvent()
     {
-        $backend = $this->getMockBuilder('Sonata\NotificationBundle\Backend\PostponeRuntimeBackend')
+        $backend = $this->getMockBuilder(PostponeRuntimeBackend::class)
             ->setMethods(['handle'])
-            ->setConstructorArgs([$this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface')])
+            ->setConstructorArgs([$this->createMock(EventDispatcherInterface::class)])
             ->getMock();
 
         $backend
@@ -132,24 +134,24 @@ class PostponeRuntimeBackendTest extends TestCase
 
     public function testStatusIsOk()
     {
-        if (!class_exists('ZendDiagnostics\Result\Success')) {
+        if (!class_exists(Success::class)) {
             $this->markTestSkipped('The class ZendDiagnostics\Result\Success does not exist');
         }
 
         $backend = new PostponeRuntimeBackend(
-            $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface'),
+            $this->createMock(EventDispatcherInterface::class),
             true
         );
 
         $status = $backend->getStatus();
-        $this->assertInstanceOf('ZendDiagnostics\Result\Success', $status);
+        $this->assertInstanceOf(Success::class, $status);
     }
 
     public function testOnCliPublishHandlesDirectly()
     {
-        $backend = $this->getMockBuilder('Sonata\NotificationBundle\Backend\PostponeRuntimeBackend')
+        $backend = $this->getMockBuilder(PostponeRuntimeBackend::class)
             ->setMethods(['handle'])
-            ->setConstructorArgs([$this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface')])
+            ->setConstructorArgs([$this->createMock(EventDispatcherInterface::class)])
             ->getMock();
 
         $backend

--- a/tests/Backend/RuntimeBackendTest.php
+++ b/tests/Backend/RuntimeBackendTest.php
@@ -16,16 +16,17 @@ use Sonata\NotificationBundle\Backend\RuntimeBackend;
 use Sonata\NotificationBundle\Exception\HandlingException;
 use Sonata\NotificationBundle\Model\MessageInterface;
 use Sonata\NotificationBundle\Tests\Entity\Message;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class RuntimeBackendTest extends TestCase
 {
     public function testCreateAndPublish()
     {
-        $dispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
         $backend = new RuntimeBackend($dispatcher);
         $message = $backend->createAndPublish('foo', ['message' => 'salut']);
 
-        $this->assertInstanceOf('Sonata\\NotificationBundle\\Model\\MessageInterface', $message);
+        $this->assertInstanceOf(MessageInterface::class, $message);
 
         $this->assertEquals(MessageInterface::STATE_DONE, $message->getState());
         $this->assertNotNull($message->getCreatedAt());
@@ -35,7 +36,7 @@ class RuntimeBackendTest extends TestCase
 
     public function testIterator()
     {
-        $dispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
         $backend = new RuntimeBackend($dispatcher);
 
         $this->assertInstanceOf('Iterator', $backend->getIterator());
@@ -45,7 +46,7 @@ class RuntimeBackendTest extends TestCase
     {
         $message = new Message();
 
-        $dispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
         $dispatcher->expects($this->once())->method('dispatch');
 
         $backend = new RuntimeBackend($dispatcher);
@@ -60,7 +61,7 @@ class RuntimeBackendTest extends TestCase
     {
         $message = new Message();
 
-        $dispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
         $dispatcher->expects($this->once())->method('dispatch')->will($this->throwException(new \RuntimeException()));
 
         $backend = new RuntimeBackend($dispatcher);
@@ -72,7 +73,7 @@ class RuntimeBackendTest extends TestCase
         } catch (HandlingException $e) {
         }
 
-        $this->assertInstanceOf('Sonata\NotificationBundle\Exception\HandlingException', $e);
+        $this->assertInstanceOf(HandlingException::class, $e);
 
         $this->assertEquals(MessageInterface::STATE_ERROR, $message->getState());
         $this->assertNotNull($message->getCreatedAt());

--- a/tests/Consumer/LoggerConsumerTest.php
+++ b/tests/Consumer/LoggerConsumerTest.php
@@ -12,8 +12,10 @@
 namespace Sonata\NotificationBundle\Tests\Consumer;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Sonata\NotificationBundle\Consumer\ConsumerEvent;
 use Sonata\NotificationBundle\Consumer\LoggerConsumer;
+use Sonata\NotificationBundle\Exception\InvalidParameterException;
 use Sonata\NotificationBundle\Tests\Entity\Message;
 
 class LoggerConsumerTest extends TestCase
@@ -26,7 +28,7 @@ class LoggerConsumerTest extends TestCase
      */
     public function testProcess($type, $calledType)
     {
-        $logger = $this->createMock('Psr\Log\LoggerInterface');
+        $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())->method($calledType);
 
         $message = new Message();
@@ -60,9 +62,9 @@ class LoggerConsumerTest extends TestCase
 
     public function testInvalidType()
     {
-        $this->expectException(\Sonata\NotificationBundle\Exception\InvalidParameterException::class);
+        $this->expectException(InvalidParameterException::class);
 
-        $logger = $this->createMock('Psr\Log\LoggerInterface');
+        $logger = $this->createMock(LoggerInterface::class);
 
         $message = new Message();
         $message->setBody([

--- a/tests/Controller/Api/MessageControllerTest.php
+++ b/tests/Controller/Api/MessageControllerTest.php
@@ -11,8 +11,16 @@
 
 namespace Sonata\NotificationBundle\Tests\Controller\Api;
 
+use FOS\RestBundle\Request\ParamFetcher;
+use FOS\RestBundle\View\View;
 use PHPUnit\Framework\TestCase;
 use Sonata\NotificationBundle\Controller\Api\MessageController;
+use Sonata\NotificationBundle\Model\MessageInterface;
+use Sonata\NotificationBundle\Model\MessageManagerInterface;
+use Sonata\PageBundle\Model\SiteManagerInterface;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -22,10 +30,10 @@ class MessageControllerTest extends TestCase
 {
     public function testGetMessagesAction()
     {
-        $messageManager = $this->createMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
+        $messageManager = $this->createMock(MessageManagerInterface::class);
         $messageManager->expects($this->once())->method('getPager')->will($this->returnValue([]));
 
-        $paramFetcher = $this->createMock('FOS\RestBundle\Request\ParamFetcher');
+        $paramFetcher = $this->createMock(ParamFetcher::class);
         $paramFetcher->expects($this->exactly(3))->method('get');
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue([]));
 
@@ -34,41 +42,41 @@ class MessageControllerTest extends TestCase
 
     public function testPostMessageAction()
     {
-        $message = $this->createMock('Sonata\NotificationBundle\Model\MessageInterface');
+        $message = $this->createMock(MessageInterface::class);
 
-        $messageManager = $this->createMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
+        $messageManager = $this->createMock(MessageManagerInterface::class);
         $messageManager->expects($this->once())->method('save')->will($this->returnValue($message));
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($message));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createMessageController(null, $messageManager, $formFactory)->postMessageAction(new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPostMessageInvalidAction()
     {
-        $message = $this->createMock('Sonata\NotificationBundle\Model\MessageInterface');
+        $message = $this->createMock(MessageInterface::class);
 
-        $messageManager = $this->createMock('Sonata\NotificationBundle\Model\MessageManagerInterface');
+        $messageManager = $this->createMock(MessageManagerInterface::class);
         $messageManager->expects($this->never())->method('save')->will($this->returnValue($message));
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createMessageController(null, $messageManager, $formFactory)->postMessageAction(new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     /**
@@ -81,13 +89,13 @@ class MessageControllerTest extends TestCase
     public function createMessageController($message = null, $messageManager = null, $formFactory = null)
     {
         if (null === $messageManager) {
-            $messageManager = $this->createMock('Sonata\PageBundle\Model\SiteManagerInterface');
+            $messageManager = $this->createMock(SiteManagerInterface::class);
         }
         if (null !== $message) {
             $messageManager->expects($this->once())->method('findOneBy')->will($this->returnValue($message));
         }
         if (null === $formFactory) {
-            $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+            $formFactory = $this->createMock(FormFactoryInterface::class);
         }
 
         return new MessageController($messageManager, $formFactory);

--- a/tests/Entity/MessageManagerTest.php
+++ b/tests/Entity/MessageManagerTest.php
@@ -11,7 +11,14 @@
 
 namespace Sonata\NotificationBundle\Tests\Entity;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use PHPUnit\Framework\TestCase;
+use Sonata\NotificationBundle\Entity\BaseMessage;
 use Sonata\NotificationBundle\Entity\MessageManager;
 use Sonata\NotificationBundle\Model\MessageInterface;
 
@@ -143,24 +150,24 @@ class MessageManagerTest extends TestCase
     }
 
     /**
-     * @return \Sonata\NotificationBundle\Tests\Entity\MessageManagerMock
+     * @return MessageManagerMock
      */
     protected function getMessageManagerMock()
     {
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
 
-        $manager = new MessageManagerMock('Sonata\notificationBundle\Tests\Entity\Message', $registry);
+        $manager = new MessageManagerMock(Message::class, $registry);
 
         return $manager;
     }
 
     /**
-     * @return \Sonata\NotificationBundle\Entity\MessageManager
+     * @return MessageManager
      */
     protected function getMessageManager($qbCallback)
     {
         $query = $this->getMockForAbstractClass(
-            'Doctrine\ORM\AbstractQuery',
+            AbstractQuery::class,
             [],
             '',
             false,
@@ -170,8 +177,8 @@ class MessageManagerTest extends TestCase
         );
         $query->expects($this->any())->method('execute')->will($this->returnValue(true));
 
-        $qb = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
-            ->setConstructorArgs([$this->createMock('Doctrine\ORM\EntityManager')])
+        $qb = $this->getMockBuilder(QueryBuilder::class)
+            ->setConstructorArgs([$this->createMock(EntityManager::class)])
             ->getMock();
 
         $qb->expects($this->any())->method('select')->will($this->returnValue($qb));
@@ -179,27 +186,29 @@ class MessageManagerTest extends TestCase
 
         $qbCallback($qb);
 
-        $repository = $this->createMock('Doctrine\ORM\EntityRepository');
+        $repository = $this->createMock(EntityRepository::class);
         $repository->expects($this->any())->method('createQueryBuilder')->will($this->returnValue($qb));
 
-        $metadata = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata = $this->createMock(ClassMetadata::class);
         $metadata->expects($this->any())->method('getFieldNames')->will($this->returnValue([
             'state',
             'type',
         ]));
 
-        $em = $this->createMock('Doctrine\ORM\EntityManager');
+        $em = $this->createMock(EntityManager::class);
         $em->expects($this->any())->method('getRepository')->will($this->returnValue($repository));
         $em->expects($this->any())->method('getClassMetadata')->will($this->returnValue($metadata));
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        return  new MessageManager('Sonata\NotificationBundle\Entity\BaseMessage', $registry);
+        return  new MessageManager(BaseMessage::class, $registry);
     }
 
     /**
-     * @return \Sonata\NotificationBundle\Tests\Entity\Message
+     * @param int $state
+     *
+     * @return Message
      */
     protected function getMessage($state = MessageInterface::STATE_OPEN)
     {

--- a/tests/Event/DoctrineOptimizeListenerTest.php
+++ b/tests/Event/DoctrineOptimizeListenerTest.php
@@ -11,9 +11,14 @@
 
 namespace Sonata\NotificationBundle\Tests\Entity;
 
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\UnitOfWork;
 use PHPUnit\Framework\TestCase;
+use Sonata\NotificationBundle\Backend\BackendInterface;
 use Sonata\NotificationBundle\Event\DoctrineOptimizeListener;
 use Sonata\NotificationBundle\Event\IterateEvent;
+use Sonata\NotificationBundle\Iterator\MessageIteratorInterface;
+use Symfony\Bridge\Doctrine\RegistryInterface;
 
 class DoctrineOptimizeListenerTest extends TestCase
 {
@@ -21,39 +26,39 @@ class DoctrineOptimizeListenerTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $manager = $this->createMock('Doctrine\ORM\EntityManager');
+        $manager = $this->createMock(EntityManager::class);
         $manager->expects($this->once())->method('isOpen')->will($this->returnValue(false));
 
-        $registry = $this->createMock('Symfony\Bridge\Doctrine\RegistryInterface');
+        $registry = $this->createMock(RegistryInterface::class);
         $registry->expects($this->once())->method('getManagers')->will($this->returnValue([
             'default' => $manager,
         ]));
 
         $optimizer = new DoctrineOptimizeListener($registry);
         $optimizer->iterate(new IterateEvent(
-            $this->createMock('Sonata\NotificationBundle\Iterator\MessageIteratorInterface'),
-            $this->createMock('Sonata\NotificationBundle\Backend\BackendInterface')
+            $this->createMock(MessageIteratorInterface::class),
+            $this->createMock(BackendInterface::class)
         ));
     }
 
     public function testOptimize()
     {
-        $unitofwork = $this->createMock('Doctrine\ORM\UnitOfWork');
+        $unitofwork = $this->createMock(UnitOfWork::class);
         $unitofwork->expects($this->once())->method('clear');
 
-        $manager = $this->createMock('Doctrine\ORM\EntityManager');
+        $manager = $this->createMock(EntityManager::class);
         $manager->expects($this->once())->method('isOpen')->will($this->returnValue(true));
         $manager->expects($this->once())->method('getUnitOfWork')->will($this->returnValue($unitofwork));
 
-        $registry = $this->createMock('Symfony\Bridge\Doctrine\RegistryInterface');
+        $registry = $this->createMock(RegistryInterface::class);
         $registry->expects($this->once())->method('getManagers')->will($this->returnValue([
             'default' => $manager,
         ]));
 
         $optimizer = new DoctrineOptimizeListener($registry);
         $optimizer->iterate(new IterateEvent(
-            $this->createMock('Sonata\NotificationBundle\Iterator\MessageIteratorInterface'),
-            $this->createMock('Sonata\NotificationBundle\Backend\BackendInterface')
+            $this->createMock(MessageIteratorInterface::class),
+            $this->createMock(BackendInterface::class)
         ));
     }
 }

--- a/tests/Exception/InvalidParameterExceptionTest.php
+++ b/tests/Exception/InvalidParameterExceptionTest.php
@@ -21,7 +21,7 @@ class InvalidParameterExceptionTest extends TestCase
 {
     public function testException()
     {
-        $this->expectException(\Sonata\NotificationBundle\Exception\InvalidParameterException::class);
+        $this->expectException(InvalidParameterException::class);
 
         throw new InvalidParameterException();
     }

--- a/tests/Iterator/MessageManagerMessageIterator.php
+++ b/tests/Iterator/MessageManagerMessageIterator.php
@@ -13,6 +13,7 @@ namespace Sonata\NotificationBundle\Tests\Iterator;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Sonata\NotificationBundle\Iterator\MessageManagerMessageIterator as Iterator;
+use Sonata\NotificationBundle\Model\Message;
 use Sonata\NotificationBundle\Tests\Entity\MessageManagerMock;
 
 /**
@@ -23,7 +24,7 @@ class MessageManagerMessageIterator extends Iterator
     public function __construct(ManagerRegistry $registry, $pause = 0, $batchSize = 10)
     {
         parent::__construct(
-            new MessageManagerMock('Sonata\NotificationBundle\Model\Message', $registry),
+            new MessageManagerMock(Message::class, $registry),
             [],
             $pause,
             $batchSize);

--- a/tests/Iterator/MessageManagerMessageIteratorTest.php
+++ b/tests/Iterator/MessageManagerMessageIteratorTest.php
@@ -26,7 +26,7 @@ class MessageManagerMessageIteratorTest extends TestCase
 
     protected function setUp()
     {
-        $this->registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $this->registry = $this->createMock(ManagerRegistry::class);
     }
 
     public function testBufferize()


### PR DESCRIPTION
I am targeting this branch, because it's BC.

## Changelog

```markdown
### Fixed
 - Replaced FQCN strings with `::class` constants
```