### PR TITLE
Removed isRequired() from Configuration

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -116,7 +116,6 @@ EOF;
                                     ->end()
                                     ->scalarNode('factory_class')
                                         ->cannotBeEmpty()
-                                        ->isRequired()
                                         ->defaultValue(AmqpConnectionFactory::class)
                                         ->info('This option defines an AMQP connection factory to be used to establish a connection with RabbitMQ.')
                                     ->end()


### PR DESCRIPTION
I am targeting this branch, because of #276 prevents the cache from refreshing. 

isRequired is forcing the user to specify the factory_class even when there is a default.

## Changelog
```markdown
### Fixed
- `isRequired()` was removed since a default is specified
```
