### PR TITLE
Make more services public by default

### DIFF
--- a/src/DependencyInjection/SonataNotificationExtension.php
+++ b/src/DependencyInjection/SonataNotificationExtension.php
@@ -78,6 +78,8 @@ class SonataNotificationExtension extends Extension
         $this->checkConfiguration($config);
 
         $container->setAlias('sonata.notification.backend', $config['backend']);
+        // NEXT_MAJOR: remove this getter when requiring sf3.4+
+        $container->getAlias('sonata.notification.backend')->setPublic(true);
         $container->setParameter('sonata.notification.backend', $config['backend']);
 
         $this->registerDoctrineMapping($config);
@@ -154,6 +156,9 @@ class SonataNotificationExtension extends Extension
 
             $this->configureDoctrineBackends($container, $config, $checkLevel, $pause, $maxAge, $batchSize);
         }
+
+        // NEXT_MAJOR: remove this getter when requiring sf3.4+
+        $container->getAlias('sonata.notification.manager.message')->setPublic(true);
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
 - Autoregister all aliases as public
```

## Subject

This patch is needed for sf 4.