### PR TITLE
using each() is deprecated since PHP 7.2

### DIFF
--- a/src/Backend/PostponeRuntimeBackend.php
+++ b/src/Backend/PostponeRuntimeBackend.php
@@ -77,13 +77,11 @@ class PostponeRuntimeBackend extends RuntimeBackend
      */
     public function onEvent(Event $event = null)
     {
-        reset($this->messages);
+        while(!empty($this->messages)) {
+            $message = array_shift($this->messages);
 
-        foreach ($this->messages as $key => $message) {
             $this->handle($message, $this->dispatcher);
         }
-
-        $this->messages = [];
     }
 
     /**

--- a/src/Backend/PostponeRuntimeBackend.php
+++ b/src/Backend/PostponeRuntimeBackend.php
@@ -81,9 +81,9 @@ class PostponeRuntimeBackend extends RuntimeBackend
 
         foreach ($this->messages as $key => $message) {
             $this->handle($message, $this->dispatcher);
-
-            unset($this->messages[$key]);
         }
+
+        $this->messages = [];
     }
 
     /**

--- a/src/Backend/PostponeRuntimeBackend.php
+++ b/src/Backend/PostponeRuntimeBackend.php
@@ -79,7 +79,7 @@ class PostponeRuntimeBackend extends RuntimeBackend
     {
         reset($this->messages);
 
-        while (list($key, $message) = each($this->messages)) {
+        foreach ($this->messages as $key => $message) {
             $this->handle($message, $this->dispatcher);
 
             unset($this->messages[$key]);

--- a/src/Backend/PostponeRuntimeBackend.php
+++ b/src/Backend/PostponeRuntimeBackend.php
@@ -77,7 +77,7 @@ class PostponeRuntimeBackend extends RuntimeBackend
      */
     public function onEvent(Event $event = null)
     {
-        while(!empty($this->messages)) {
+        while (!empty($this->messages)) {
             $message = array_shift($this->messages);
 
             $this->handle($message, $this->dispatcher);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because its BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #306

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `each()` is deprecated since PHP 7.2
```