### PR TITLE
Fix variable override

### DIFF
--- a/src/DependencyInjection/Compiler/NotificationCompilerPass.php
+++ b/src/DependencyInjection/Compiler/NotificationCompilerPass.php
@@ -35,8 +35,7 @@ class NotificationCompilerPass implements CompilerPassInterface
         $informations = [];
 
         foreach ($container->findTaggedServiceIds('sonata.notification.consumer') as $id => $events) {
-            $definition = $container->getDefinition($id);
-            $definition->setPublic(true);
+            $container->getDefinition($id)->setPublic(true);
 
             foreach ($events as $event) {
                 $priority = isset($event['priority']) ? $event['priority'] : 0;


### PR DESCRIPTION
I am targeting this branch, because this one has the issue https://github.com/sonata-project/SonataPageBundle/issues/950.

Closes https://github.com/sonata-project/SonataPageBundle/issues/950

## Changelog

```markdown
### Fixed
- Remove var **definition** override
```

## Subject

Fix variable override which prevent snapshot creation command in Sonata Admin