### PR TITLE
Commands as services

### DIFF
--- a/src/DependencyInjection/SonataNotificationExtension.php
+++ b/src/DependencyInjection/SonataNotificationExtension.php
@@ -54,6 +54,7 @@ class SonataNotificationExtension extends Extension
         $loader->load('consumer.xml');
         $loader->load('selector.xml');
         $loader->load('event.xml');
+        $loader->load('command.xml');
 
         if ($config['consumers']['register_default']) {
             $loader->load('default_consumers.xml');

--- a/src/Resources/config/command.xml
+++ b/src/Resources/config/command.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Sonata\NotificationBundle\Command\ConsumerHandlerCommand" class="Sonata\NotificationBundle\Command\ConsumerHandlerCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\NotificationBundle\Command\CreateAndPublishCommand" class="Sonata\NotificationBundle\Command\CreateAndPublishCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\NotificationBundle\Command\ListHandlerCommand" class="Sonata\NotificationBundle\Command\ListHandlerCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\NotificationBundle\Command\ListQueuesCommand" class="Sonata\NotificationBundle\Command\ListQueuesCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\NotificationBundle\Command\RestartCommand" class="Sonata\NotificationBundle\Command\RestartCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\NotificationBundle\Command\CleanupCommand" class="Sonata\NotificationBundle\Command\CleanupCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targeting this branch, because this is a BC fix.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Commands not working on symfony4
```

## Subject

On symfony4 commands are not working as they are not registered as a services, this fixes it.