### PR TITLE
Remove compatibility with FOSRest < 2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,11 +38,12 @@
         "zendframework/zenddiagnostics": "^1.0"
     },
     "conflict": {
+        "friendsofsymfony/rest-bundle": "<2.1 || >=3.0",
         "jms/serializer": "<0.13",
         "sonata-project/admin-bundle": "<3.1"
     },
     "require-dev": {
-        "friendsofsymfony/rest-bundle": "^1.5 || ^2.1",
+        "friendsofsymfony/rest-bundle": "^2.1",
         "guzzlehttp/guzzle": "^3.8",
         "jms/serializer-bundle": "^0.13 || ^1.0",
         "liip/monitor-bundle": "^2.0",

--- a/tests/Controller/Api/MessageControllerTest.php
+++ b/tests/Controller/Api/MessageControllerTest.php
@@ -55,9 +55,9 @@ class MessageControllerTest extends TestCase
         $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
-        $view = $this->createMessageController(null, $messageManager, $formFactory)->postMessageAction(new Request());
+        $message = $this->createMessageController(null, $messageManager, $formFactory)->postMessageAction(new Request());
 
-        $this->assertInstanceOf(View::class, $view);
+        $this->assertInstanceOf(MessageInterface::class, $message);
     }
 
     public function testPostMessageInvalidAction()
@@ -74,9 +74,9 @@ class MessageControllerTest extends TestCase
         $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
-        $view = $this->createMessageController(null, $messageManager, $formFactory)->postMessageAction(new Request());
+        $form = $this->createMessageController(null, $messageManager, $formFactory)->postMessageAction(new Request());
 
-        $this->assertInstanceOf(FormInterface::class, $view);
+        $this->assertInstanceOf(FormInterface::class, $form);
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed compatibility with older versions of FOSRestBundle (<2.1)
```

## Subject

<!-- Describe your Pull Request content here -->
Since dropping a dependency is not a BC break, this is a good start, because we are doing a lot of code just to keep compat with FOSRest 1.