### PR TITLE
Minor composer improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "enqueue/amqp-lib": "^0.8",
-        "sonata-project/core-bundle": "^3.0",
-        "sonata-project/datagrid-bundle": "^2.2.1",
+        "sonata-project/core-bundle": "^3.9",
+        "sonata-project/datagrid-bundle": "^2.3",
         "sonata-project/doctrine-extensions": "^1.0",
-        "sonata-project/easy-extends-bundle": "^2.2",
+        "sonata-project/easy-extends-bundle": "^2.5",
         "symfony/config": "^2.8 || ^3.2 || ^4.0",
         "symfony/console": "^2.8 || ^3.2 || ^4.0",
         "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
@@ -45,12 +45,12 @@
     "require-dev": {
         "friendsofsymfony/rest-bundle": "^2.1",
         "guzzlehttp/guzzle": "^3.8",
-        "jms/serializer-bundle": "^0.13 || ^1.0",
+        "jms/serializer-bundle": "^1.0 || ^2.0",
         "liip/monitor-bundle": "^2.0",
         "nelmio/api-doc-bundle": "^2.4",
-        "sonata-project/doctrine-orm-admin-bundle": "^3.0",
-        "swiftmailer/swiftmailer": "^4.3 || ^5.0",
-        "symfony/phpunit-bridge": "^3.3 || ^4.0"
+        "sonata-project/doctrine-orm-admin-bundle": "^3.4",
+        "swiftmailer/swiftmailer": "^5.0 || ^6.0",
+        "symfony/phpunit-bridge": "^4.0"
     },
     "suggest": {
         "guzzlehttp/guzzle": "If you want to get a status report when using the rabbitMQ backend.",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->
- Allow serialized-bundle 2.0 (and remove 0.x)
- Allow swiftmailer 6.0 (and remove 4.x)
- PHPUnit bridge 4.0
- Up sonata dependencies