### PR TITLE
Add possibility to add an attachment to SwiftMailer Consumer

### DIFF
--- a/docs/reference/usage.rst
+++ b/docs/reference/usage.rst
@@ -25,6 +25,10 @@ Calling an existing consumer
             'text' => 'hello'
         ),
         'subject' => 'Contact form',
+        'attachment' => array(
+            'file' => '/path/to/file',
+            'name' => 'fileName'
+        ),
     ));
 
 

--- a/src/Consumer/SwiftMailerConsumer.php
+++ b/src/Consumer/SwiftMailerConsumer.php
@@ -82,6 +82,12 @@ class SwiftMailerConsumer implements ConsumerInterface
             $mail->addPart($html, 'text/html');
         }
 
+        if ($attachment = $message->getValue(['attachment', 'file'])) {
+            $attachmentName = $message->getValue(['attachment', 'name']);
+
+            $mail->attach(new \Swift_Attachment($attachment, $attachmentName));
+        }
+
         $this->mailer->send($mail);
     }
 }

--- a/tests/Consumer/SwiftMailerConsumerTest.php
+++ b/tests/Consumer/SwiftMailerConsumerTest.php
@@ -71,6 +71,10 @@ class SwiftMailerConsumerTest extends TestCase
                 'text' => 'message text',
                 'html' => 'message html',
             ],
+            'attachment' => [
+                'file' => 'path to file',
+                'name' => 'file name',
+            ],
         ]);
 
         $mail = $this->createMock('Swift_Message');
@@ -92,6 +96,9 @@ class SwiftMailerConsumerTest extends TestCase
                 [$this->equalTo('message text'), $this->equalTo('text/plain')],
                 [$this->equalTo('message html'), $this->equalTo('text/html')]
             )
+            ->willReturnSelf();
+        $mail->expects($this->once())
+            ->method('attach')
             ->willReturnSelf();
 
         $this->mailer->expects($this->once())->method('createMessage')->will($this->returnValue($mail));


### PR DESCRIPTION
## Changelog

```markdown
### Added
- Added possibility to add an attachment to SwiftMailer Consumer
```
## Subject

In the current SwiftMailerConsumer we can't attach files, this PR add this possibility.
