### PR TITLE
Disable admin by default

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -16,3 +16,7 @@ UPGRADE FROM 3.x to 4.0
 * `AMQPMessageIterator::AMQMessage` property was removed. Consider removing dependency on it or use `Sonata\NotificationBundle\Model\Message::getValue('interopMessage')`.
 * `Sonata\NotificationBundle\Model\Message::getValue('AMQMessage')` is not available any more. Consider removing dependency on it or use `Sonata\NotificationBundle\Model\Message::getValue('interopMessage')`.
 *  `AMQPBackend::getChannel()` method was removed. Consider removing dependency on it or use `AMQPBackend::getContext()` method.
+
+### Configuration
+
+* `sonata_notification.admin.enabled` is not enabled by default

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -153,7 +153,7 @@ EOF;
                 ->addDefaultsIfNotSet()
                 ->children()
                     ->booleanNode('enabled')
-                        ->defaultTrue()
+                        ->defaultFalse()
                     ->end()
                     ->arrayNode('message')
                         ->addDefaultsIfNotSet()


### PR DESCRIPTION
I am targeting this branch, because this is BC break

## Changelog
```markdown
### Changed
- Disable admin configuration by default
```

## Subject

I believe, that disabling admin in configuration is more correct, because it can be enabled only when `sonata.notification.backend.doctrine` was enabled.

A default configuration, i.e. recipe for `sonata-project/notification-bundle` could be like this:

```yaml
sonata_notification:
    consumers:
        register_default: false
    admin:
        enabled: false
```

Also, default configuration could contain commented configuration for `backend: sonata.notification.backend.rabbitmq`. Anyway, i have already created PR with recipe for this bundle in febuary https://github.com/symfony/recipes-contrib/pull/302

Additional configuration, i.e. a recipe for a new package `sonata-project/notification-orm-pack` could be like this (i created a [gist](https://gist.github.com/covex-nn/d34ec8f3a97f566e581979ecff041954) with entity class):

```yaml
sonata_notification:
    backend: sonata.notification.backend.doctrine
    backends:
        doctrine: ~
    class:
        message: App\Entity\SonataNotificationMessage
    admin:
        enabled: true
```

So, additional configuration will override default.