### PR TITLE
Update stats for BackendHealthCheck in case of doctrine backend is used

### DIFF
--- a/src/Backend/MessageManagerBackendDispatcher.php
+++ b/src/Backend/MessageManagerBackendDispatcher.php
@@ -97,7 +97,7 @@ class MessageManagerBackendDispatcher extends QueueBackendDispatcher
      */
     public function getStatus()
     {
-        return new Success('Channel is running (RabbitMQ) and consumers for all queues available.');
+        return new Success('Channel is running (Database) and consumers for all queues available.');
     }
 
     /**

--- a/src/Entity/MessageManager.php
+++ b/src/Entity/MessageManager.php
@@ -87,7 +87,7 @@ class MessageManager extends BaseEntityManager implements MessageManagerInterfac
             MessageInterface::STATE_OPEN => 0,
         ];
 
-        foreach ($stm->fetch() as $data) {
+        while ($data = $stm->fetch()) {
             $states[$data['state']] = $data['cnt'];
         }
 


### PR DESCRIPTION
## Changelog

```markdown
### Fixed
- Data fetched from stats counts are now properly manipulated (in case of doctrine backend is used)
- Typo in message status
```

## Subject

The goal of this PR is to fix the way data are manipulated in the case of doctrine backend is used. An SQL query fetch the stats but it raise an error.

**Before**
In the foreach `$data = '-2'`

**After**
In the while `$data = ['state' => -2, 'cnt' => 3]`
