### PR TITLE
Enable API and configure AdminBundle only for doctrine backend

### DIFF
--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -6,6 +6,8 @@ SonataNotificationBundle embeds a Controller to provide an API through FOSRestBu
 Setup
 -----
 
+API is only available with ``sonata.notification.backend.doctrine`` as notification backend.
+
 If you wish to use it, you must first follow the installation instructions of both bundles:
 
 * `FOSRestBundle <https://github.com/FriendsOfSymfony/FOSRestBundle>`_

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -8,8 +8,8 @@ To begin, add the dependent bundles:
     composer require sonata-project/notification-bundle
     composer require enqueue/amqp-lib --no-update # optional
     composer require liip/monitor-bundle --no-update     # optional
-    composer require friendsofsymfony/rest-bundle  --no-update # optional when using api
-    composer require nelmio/api-doc-bundle  --no-update # optional when using api
+    composer require friendsofsymfony/rest-bundle  --no-update # optional when using api with doctrine backend
+    composer require nelmio/api-doc-bundle  --no-update # optional when using api with doctrine backend
     composer update
 
 

--- a/src/DependencyInjection/SonataNotificationExtension.php
+++ b/src/DependencyInjection/SonataNotificationExtension.php
@@ -55,26 +55,26 @@ class SonataNotificationExtension extends Extension
         $loader->load('consumer.xml');
         $loader->load('command.xml');
 
+        $bundles = $container->getParameter('kernel.bundles');
+
         if ('sonata.notification.backend.doctrine' === $config['backend']) {
             $loader->load('doctrine_orm.xml');
             $loader->load('selector.xml');
             $loader->load('event.xml');
+
+            if (isset($bundles['FOSRestBundle'], $bundles['NelmioApiDocBundle'])) {
+                $loader->load('api_controllers.xml');
+                $loader->load('api_form.xml');
+            }
+
+            // for now, only support for ORM
+            if ($config['admin']['enabled'] && isset($bundles['SonataDoctrineORMAdminBundle'])) {
+                $loader->load('admin.xml');
+            }
         }
 
         if ($config['consumers']['register_default']) {
             $loader->load('default_consumers.xml');
-        }
-
-        $bundles = $container->getParameter('kernel.bundles');
-
-        if (isset($bundles['FOSRestBundle'], $bundles['NelmioApiDocBundle'])) {
-            $loader->load('api_controllers.xml');
-            $loader->load('api_form.xml');
-        }
-
-        // for now, only support for ORM
-        if ($config['admin']['enabled'] && isset($bundles['SonataDoctrineORMAdminBundle'])) {
-            $loader->load('admin.xml');
         }
 
         if (isset($bundles['LiipMonitorBundle'])) {


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

Closes #322

Related to #324

## Changelog
<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- API and Admin services are only available when using doctine as a backend
```

## Subject

Since #314 and when backend differs from `sonata.notification.backend.doctrine`, `sonata.notification.manager.message` service, required for API, is not available.

With this PR `api_controllers.xml`, `api_form.xml` and `admin.xml` files are loaded by `SonataNotificationExtension` only when using doctrine as notification backend.