### PR TITLE
Move enqueue/amqp-lib to require-dev section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "enqueue/amqp-lib": "^0.8",
         "sonata-project/core-bundle": "^3.9",
         "sonata-project/datagrid-bundle": "^2.3",
         "sonata-project/doctrine-extensions": "^1.0",
@@ -43,6 +42,7 @@
         "sonata-project/admin-bundle": "<3.1"
     },
     "require-dev": {
+        "enqueue/amqp-lib": "^0.8",
         "friendsofsymfony/rest-bundle": "^2.1",
         "guzzlehttp/guzzle": "^3.8",
         "jms/serializer-bundle": "^1.0 || ^2.0",


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- enqueue/amqp-lib is optional dependency now
```

## Subject

Installation [docs](https://sonata-project.org/bundles/notification/3-x/doc/reference/installation.html) says that `enqueue/amqp-lib` could be optionally installed after installing `sonata-project/notification-bundle`, but it is always installed with composer, because it required dependency. This PR makes amqp-lib optional.

`enqueue/amqp-lib` is inside `require` section of composer.json since #276