### PR TITLE
Force use existing translation strings in breadcrumb for Message entity

### DIFF
--- a/src/Admin/MessageAdmin.php
+++ b/src/Admin/MessageAdmin.php
@@ -20,6 +20,8 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
 class MessageAdmin extends AbstractAdmin
 {
+    protected $classnameLabel = 'Message';
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
I am targeting this branch, because this is BC patch.

See https://github.com/sonata-project/media-orm-pack/issues/3, this PR solves similar issue

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Force use existing translation strings in breadcrump for Message entity in Admin panel
```

## Subject

If a last part of Message class name differs from `Message`, then `Admin` will try to use non-existing translation string for breadcrumbs instead of `breadcrumb.link_message_list`, i.e. it will use `breadcrumb.link_sonata_notification_message_list` for `SonataNotificationMessage`.

With this PR `Admin` will be forced to use existing translation strings.