### PR TITLE
Skip creating redundant indexes for message table via EasyExtends

### DIFF
--- a/src/DependencyInjection/SonataNotificationExtension.php
+++ b/src/DependencyInjection/SonataNotificationExtension.php
@@ -169,6 +169,9 @@ class SonataNotificationExtension extends Extension
      */
     public function registerDoctrineMapping(array $config)
     {
+        @trigger_error(sprintf(
+            'Registering doctrine mappings in %s is deprecated. Use XML mapping instead.', __METHOD__
+        ), E_USER_DEPRECATED);
     }
 
     /**

--- a/src/DependencyInjection/SonataNotificationExtension.php
+++ b/src/DependencyInjection/SonataNotificationExtension.php
@@ -11,7 +11,6 @@
 
 namespace Sonata\NotificationBundle\DependencyInjection;
 
-use Sonata\EasyExtendsBundle\Mapper\DoctrineCollector;
 use Sonata\NotificationBundle\Backend\AMQPBackend;
 use Sonata\NotificationBundle\Backend\MessageManagerBackend;
 use Sonata\NotificationBundle\Model\MessageInterface;
@@ -86,7 +85,6 @@ class SonataNotificationExtension extends Extension
         $container->getAlias('sonata.notification.backend')->setPublic(true);
         $container->setParameter('sonata.notification.backend', $config['backend']);
 
-        $this->registerDoctrineMapping($config);
         $this->registerParameters($container, $config);
         $this->configureBackends($container, $config);
         $this->configureClass($container, $config);
@@ -163,19 +161,14 @@ class SonataNotificationExtension extends Extension
     }
 
     /**
-     * @param array $config
+     * NEXT_MAJOR: remove this method, since all Doctrine mappings are already
+     *             described in Resources/config/doctrine/BaseMessage.orm.xml.
+     *
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     *             EasyExtends should be used only for associations between entities.
      */
     public function registerDoctrineMapping(array $config)
     {
-        $collector = DoctrineCollector::getInstance();
-
-        $collector->addIndex($config['class']['message'], 'idx_state', [
-            'state',
-        ]);
-
-        $collector->addIndex($config['class']['message'], 'idx_created_at', [
-            'created_at',
-        ]);
     }
 
     /**


### PR DESCRIPTION
I am targeting this branch, because this is BC patch.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Skiped creating redundant indexes via EasyExtendsBundle

### Deprecated
- Registering doctrine mappings in SonataNotificationExtension is deprecated
```

## Subject

EasyExtends should be used only for associations between entities. Before this PR indexes for `state` and `created_at` columns of `BaseMessage` mapped-superclass were created by `Resources/config/doctrine/BaseMessage.orm.xml` and `SonataNotificationExtension::registerDoctrineMappings`. Indexes were equal, but had different names.

So, i removed everything from `SonataNotificationExtension::registerDoctrineMappings` and marked this method as deprecated.