### PR TITLE
Added service aliases for autowiring

### DIFF
--- a/src/Backend/AMQPBackendDispatcher.php
+++ b/src/Backend/AMQPBackendDispatcher.php
@@ -156,7 +156,7 @@ class AMQPBackendDispatcher extends QueueBackendDispatcher
 
         $default = null;
 
-        if (0 === count($this->queues)) {
+        if (0 === \count($this->queues)) {
             foreach ($this->backends as $backend) {
                 if ('default' === $backend['type']) {
                     return $backend['backend'];
@@ -227,14 +227,14 @@ class AMQPBackendDispatcher extends QueueBackendDispatcher
                 }
             }
 
-            if ($checked !== count($this->queues)) {
+            if ($checked !== \count($this->queues)) {
                 return new Failure(
                     'Not all queues for the available notification types registered in the rabbitmq broker. '
                     .'Are the consumer commands running?'
                 );
             }
 
-            if (count($missingConsumers) > 0) {
+            if (\count($missingConsumers) > 0) {
                 return new Failure(
                     'There are no rabbitmq consumers running for the queues: '.implode(', ', $missingConsumers)
                 );

--- a/src/Backend/MessageManagerBackendDispatcher.php
+++ b/src/Backend/MessageManagerBackendDispatcher.php
@@ -68,7 +68,7 @@ class MessageManagerBackendDispatcher extends QueueBackendDispatcher
         }
 
         foreach ($this->backends as $backend) {
-            if (in_array($type, $backend['types'])) {
+            if (\in_array($type, $backend['types'])) {
                 return $backend['backend'];
             }
         }

--- a/src/Backend/PostponeRuntimeBackend.php
+++ b/src/Backend/PostponeRuntimeBackend.php
@@ -107,6 +107,6 @@ class PostponeRuntimeBackend extends RuntimeBackend
      */
     protected function isCommandLineInterface()
     {
-        return 'cli' === PHP_SAPI;
+        return 'cli' === \PHP_SAPI;
     }
 }

--- a/src/Command/ConsumerHandlerCommand.php
+++ b/src/Command/ConsumerHandlerCommand.php
@@ -50,11 +50,11 @@ class ConsumerHandlerCommand extends ContainerAwareCommand
                 if (!$listener[0] instanceof ConsumerInterface) {
                     throw new \RuntimeException(sprintf(
                         'The registered service does not implement the ConsumerInterface (class=%s',
-                        get_class($listener[0])
+                        \get_class($listener[0])
                     ));
                 }
 
-                $output->writeln(sprintf('   > %s', get_class($listener[0])));
+                $output->writeln(sprintf('   > %s', \get_class($listener[0])));
             }
         }
 
@@ -76,13 +76,13 @@ class ConsumerHandlerCommand extends ContainerAwareCommand
             $output->writeln(sprintf(
                 '[%s] <info>Starting the backend handler</info> - %s',
                 $startDate->format('r'),
-                get_class($backend)
+                \get_class($backend)
             ));
         } else {
             $output->writeln(sprintf(
                 '[%s] <info>Starting the backend handler</info> - %s (type: %s)',
                 $startDate->format('r'),
-                get_class($backend),
+                \get_class($backend),
                 $type
             ));
         }
@@ -155,7 +155,7 @@ class ConsumerHandlerCommand extends ContainerAwareCommand
     {
         throw new \RuntimeException(
             "The requested backend for the type '".$type." 'does not exist. \nMake sure the backend '".
-            get_class($backend)."' \nsupports multiple queues and the routing_key is defined. (Currently rabbitmq only)"
+            \get_class($backend)."' \nsupports multiple queues and the routing_key is defined. (Currently rabbitmq only)"
         );
     }
 

--- a/src/Command/ListQueuesCommand.php
+++ b/src/Command/ListQueuesCommand.php
@@ -36,7 +36,7 @@ class ListQueuesCommand extends ContainerAwareCommand
 
         if (!$backend instanceof QueueDispatcherInterface) {
             $output->writeln(
-                'The backend class <info>'.get_class($backend).'</info> does not provide multiple queues.'
+                'The backend class <info>'.\get_class($backend).'</info> does not provide multiple queues.'
             );
 
             return;

--- a/src/Command/RestartCommand.php
+++ b/src/Command/RestartCommand.php
@@ -67,7 +67,7 @@ class RestartCommand extends ContainerAwareCommand
             );
         }
 
-        if (0 == count($messages)) {
+        if (0 == \count($messages)) {
             $output->writeln('Nothing to restart, bye.');
 
             return;

--- a/src/Consumer/LoggerConsumer.php
+++ b/src/Consumer/LoggerConsumer.php
@@ -45,7 +45,7 @@ class LoggerConsumer implements ConsumerInterface
             @trigger_error(
                 sprintf(
                     'Using an instance of "%s" is deprecated since version 2.3. Use Psr\Log\LoggerInterface instead.',
-                    get_class($logger)
+                    \get_class($logger)
                 ),
                 E_USER_DEPRECATED
             );

--- a/src/Controller/Api/MessageController.php
+++ b/src/Controller/Api/MessageController.php
@@ -87,7 +87,7 @@ class MessageController
 
         if (!$sort) {
             $sort = [];
-        } elseif (!is_array($sort)) {
+        } elseif (!\is_array($sort)) {
             $sort = [$sort => 'asc'];
         }
 

--- a/src/DependencyInjection/SonataNotificationExtension.php
+++ b/src/DependencyInjection/SonataNotificationExtension.php
@@ -183,7 +183,7 @@ class SonataNotificationExtension extends Extension
      */
     protected function checkConfiguration(array $config)
     {
-        if (isset($config['backends']) && count($config['backends']) > 1) {
+        if (isset($config['backends']) && \count($config['backends']) > 1) {
             throw new \RuntimeException('more than one backend configured, you can have only one backend configuration');
         }
 
@@ -239,7 +239,7 @@ class SonataNotificationExtension extends Extension
         $definition = $container->getDefinition('sonata.notification.backend.doctrine');
 
         // no queue defined, set a default one
-        if (0 == count($queues)) {
+        if (0 == \count($queues)) {
             $queues = [[
                 'queue' => 'default',
                 'default' => true,
@@ -251,14 +251,14 @@ class SonataNotificationExtension extends Extension
         $declaredQueues = [];
 
         foreach ($queues as $pos => &$queue) {
-            if (in_array($queue['queue'], $declaredQueues)) {
+            if (\in_array($queue['queue'], $declaredQueues)) {
                 throw new \RuntimeException('The doctrine backend does not support 2 identicals queue name, please rename one queue');
             }
 
             $declaredQueues[] = $queue['queue'];
 
             // make the configuration compatible with old code and rabbitmq
-            if (isset($queue['routing_key']) && strlen($queue['routing_key']) > 0) {
+            if (isset($queue['routing_key']) && \strlen($queue['routing_key']) > 0) {
                 $queue['types'] = [$queue['routing_key']];
             }
 
@@ -336,7 +336,7 @@ class SonataNotificationExtension extends Extension
         $baseExchange = $config['backends']['rabbitmq']['exchange'];
         $amqBackends = [];
 
-        if (0 == count($queues)) {
+        if (0 == \count($queues)) {
             $queues = [[
                 'queue' => 'default',
                 'default' => true,
@@ -353,7 +353,7 @@ class SonataNotificationExtension extends Extension
         $routingKeys = $this->getQueuesParameters('routing_key', $queues);
 
         foreach ($deadLetterRoutingKeys as $key) {
-            if (!in_array($key, $routingKeys)) {
+            if (!\in_array($key, $routingKeys)) {
                 throw new \RuntimeException(sprintf(
                     'You must configure the queue having the routing_key "%s" same as dead_letter_routing_key', $key
                 ));
@@ -364,7 +364,7 @@ class SonataNotificationExtension extends Extension
 
         $defaultSet = false;
         foreach ($queues as $pos => $queue) {
-            if (in_array($queue['queue'], $declaredQueues)) {
+            if (\in_array($queue['queue'], $declaredQueues)) {
                 throw new \RuntimeException('The RabbitMQ backend does not support 2 identicals queue name, please rename one queue');
             }
 
@@ -378,7 +378,7 @@ class SonataNotificationExtension extends Extension
                 }
             }
 
-            if (in_array($queue['routing_key'], $deadLetterRoutingKeys)) {
+            if (\in_array($queue['routing_key'], $deadLetterRoutingKeys)) {
                 $exchange = $this->getAMQPDeadLetterExchangeByRoutingKey($queue['routing_key'], $queues);
             } else {
                 $exchange = $baseExchange;

--- a/src/Entity/MessageManager.php
+++ b/src/Entity/MessageManager.php
@@ -157,11 +157,11 @@ class MessageManager extends BaseEntityManager implements MessageManagerInterfac
 
         $fields = $this->getEntityManager()->getClassMetadata($this->class)->getFieldNames();
         foreach ($sort as $field => $direction) {
-            if (!in_array($field, $fields)) {
+            if (!\in_array($field, $fields)) {
                 throw new \RuntimeException(sprintf("Invalid sort field '%s' in '%s' class", $field, $this->class));
             }
         }
-        if (0 == count($sort)) {
+        if (0 == \count($sort)) {
             $sort = ['type' => 'ASC'];
         }
         foreach ($sort as $field => $direction) {
@@ -208,7 +208,7 @@ class MessageManager extends BaseEntityManager implements MessageManagerInterfac
 
         $parameters['state'] = $state;
 
-        if (count($types) > 0) {
+        if (\count($types) > 0) {
             if (array_key_exists('exclude', $types) || array_key_exists('include', $types)) {
                 if (array_key_exists('exclude', $types)) {
                     $query->andWhere('m.type NOT IN (:exclude)');

--- a/src/Iterator/MessageManagerMessageIterator.php
+++ b/src/Iterator/MessageManagerMessageIterator.php
@@ -109,7 +109,7 @@ class MessageManagerMessageIterator implements MessageIteratorInterface
      */
     public function isBufferEmpty()
     {
-        return 0 === count($this->buffer);
+        return 0 === \count($this->buffer);
     }
 
     /**
@@ -117,7 +117,7 @@ class MessageManagerMessageIterator implements MessageIteratorInterface
      */
     protected function setCurrent()
     {
-        if (0 === count($this->buffer)) {
+        if (0 === \count($this->buffer)) {
             $this->bufferize($this->types);
         }
 
@@ -134,7 +134,7 @@ class MessageManagerMessageIterator implements MessageIteratorInterface
         while (true) {
             $this->buffer = $this->findNextMessages($types);
 
-            if (count($this->buffer) > 0) {
+            if (\count($this->buffer) > 0) {
                 break;
             }
 

--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -99,7 +99,7 @@ class Message implements MessageInterface
      */
     public function getValue($names, $default = null)
     {
-        if (!is_array($names)) {
+        if (!\is_array($names)) {
             $names = [$names];
         }
 

--- a/src/Resources/config/backend.xml
+++ b/src/Resources/config/backend.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
+        <service id="Sonata\NotificationBundle\Backend\BackendInterface" alias="sonata.notification.backend" public="true"/>
         <service id="sonata.notification.backend.runtime" class="Sonata\NotificationBundle\Backend\RuntimeBackend" public="true">
             <argument type="service" id="sonata.notification.dispatcher"/>
         </service>

--- a/src/Resources/config/doctrine_orm.xml
+++ b/src/Resources/config/doctrine_orm.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
+        <service id="Sonata\NotificationBundle\Model\MessageManagerInterface" alias="sonata.notification.manager.message" public="true"/>
         <service id="sonata.notification.manager.message.default" class="Sonata\NotificationBundle\Entity\MessageManager">
             <argument>%sonata.notification.message.class%</argument>
             <argument type="service" id="doctrine"/>

--- a/src/Selector/ErroneousMessagesSelector.php
+++ b/src/Selector/ErroneousMessagesSelector.php
@@ -56,7 +56,7 @@ class ErroneousMessagesSelector
             'maxAttempts' => $maxAttempts,
         ];
 
-        if (count($types) > 0) {
+        if (\count($types) > 0) {
             $query->andWhere('m.type IN (:types)');
             $parameters['types'] = $types;
         }

--- a/src/SonataNotificationBundle.php
+++ b/src/SonataNotificationBundle.php
@@ -34,9 +34,9 @@ class SonataNotificationBundle extends Bundle
      */
     public function boot()
     {
-        if (!defined('AMQP_DEBUG')) {
+        if (!\defined('AMQP_DEBUG')) {
             //            define('AMQP_DEBUG', $this->container->getParameter('kernel.debug'));
-            define('AMQP_DEBUG', false);
+            \define('AMQP_DEBUG', false);
         }
 
         $this->registerFormMapping();

--- a/tests/Backend/AMQPBackendDispatcherTest.php
+++ b/tests/Backend/AMQPBackendDispatcherTest.php
@@ -13,7 +13,6 @@ namespace Sonata\NotificationBundle\Tests\Backend;
 
 use Enqueue\AmqpLib\AmqpConnectionFactory;
 use Interop\Amqp\AmqpContext;
-use MyProject\Proxies\__CG__\stdClass;
 use PHPUnit\Framework\TestCase;
 use Sonata\NotificationBundle\Backend\AMQPBackend;
 use Sonata\NotificationBundle\Backend\AMQPBackendDispatcher;

--- a/tests/Backend/MessageManagerBackendTest.php
+++ b/tests/Backend/MessageManagerBackendTest.php
@@ -104,7 +104,7 @@ class MessageManagerBackendTest extends TestCase
 
         $status = $backend->getStatus();
 
-        $this->assertInstanceOf(get_class($expectedStatus), $status);
+        $this->assertInstanceOf(\get_class($expectedStatus), $status);
         $this->assertEquals($message, $status->getMessage());
     }
 

--- a/tests/Controller/Api/MessageControllerTest.php
+++ b/tests/Controller/Api/MessageControllerTest.php
@@ -12,7 +12,6 @@
 namespace Sonata\NotificationBundle\Tests\Controller\Api;
 
 use FOS\RestBundle\Request\ParamFetcher;
-use FOS\RestBundle\View\View;
 use PHPUnit\Framework\TestCase;
 use Sonata\NotificationBundle\Controller\Api\MessageController;
 use Sonata\NotificationBundle\Model\MessageInterface;

--- a/tests/Iterator/MessageManagerMessageIteratorTest.php
+++ b/tests/Iterator/MessageManagerMessageIteratorTest.php
@@ -35,7 +35,7 @@ class MessageManagerMessageIteratorTest extends TestCase
 
         $iterator->_bufferize();
 
-        $this->assertEquals(10, count($iterator->getBuffer()));
+        $this->assertCount(10, $iterator->getBuffer());
     }
 
     public function testIterations()


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `Sonata\NotificationBundle\Backend\BackendInterface` service alias
- Added `Sonata\NotificationBundle\Entity\MessageManager` service alias
```


## Subject

Added class aliases for symfony autowiring.
