### PR TITLE
Issue when running sonata:notification:start #339

### DIFF
--- a/src/Resources/config/core.xml
+++ b/src/Resources/config/core.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sonata.notification.dispatcher" class="Symfony\Component\EventDispatcher\EventDispatcher">
+        <service id="sonata.notification.dispatcher" class="Symfony\Component\EventDispatcher\EventDispatcher" public="true">
         </service>
     </services>
 </container>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #339 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Changed
- made the "sonata.notification.dispatcher" service public to fix a bug when running `sonata:notification:start`
```


## Subject

<!-- Describe your Pull Request content here -->
[Sat, 27 Oct 2018 17:14:21 +0000] Checking listeners

Added public="true" to core.xml