### PR TITLE
fix(message-order): consume message by creation order (fifo)

### DIFF
--- a/src/Backend/AMQPBackend.php
+++ b/src/Backend/AMQPBackend.php
@@ -59,22 +59,22 @@ class AMQPBackend implements BackendInterface
     private $recover;
 
     /**
-     * @var null|string
+     * @var string|null
      */
     private $deadLetterExchange;
 
     /**
-     * @var null|string
+     * @var string|null
      */
     private $deadLetterRoutingKey;
 
     /**
-     * @var null|int
+     * @var int|null
      */
     private $ttl;
 
     /**
-     * @var null|int
+     * @var int|null
      */
     private $prefetchCount;
 
@@ -90,7 +90,7 @@ class AMQPBackend implements BackendInterface
      * @param string   $key
      * @param string   $deadLetterExchange
      * @param string   $deadLetterRoutingKey
-     * @param null|int $ttl
+     * @param int|null $ttl
      */
     public function __construct($exchange, $queue, $recover, $key, $deadLetterExchange = null, $deadLetterRoutingKey = null, $ttl = null, $prefetchCount = null)
     {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -29,7 +29,7 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder('sonata_notification');
 
         // Keep compatibility with symfony/config < 4.2
-        if (!\method_exists($treeBuilder, 'getRootNode')) {
+        if (!method_exists($treeBuilder, 'getRootNode')) {
             $rootNode = $treeBuilder->root('sonata_notification')->children();
         } else {
             $rootNode = $treeBuilder->getRootNode()->children();
@@ -193,7 +193,7 @@ EOF;
         $treeBuilder = new TreeBuilder('queues');
 
         // Keep compatibility with symfony/config < 4.2
-        if (!\method_exists($treeBuilder, 'getRootNode')) {
+        if (!method_exists($treeBuilder, 'getRootNode')) {
             $node = $treeBuilder->root('queues');
         } else {
             $node = $treeBuilder->getRootNode();

--- a/src/Iterator/MessageManagerMessageIterator.php
+++ b/src/Iterator/MessageManagerMessageIterator.php
@@ -123,7 +123,7 @@ class MessageManagerMessageIterator implements MessageIteratorInterface
             $this->bufferize($this->types);
         }
 
-        $this->current = array_pop($this->buffer);
+        $this->current = array_shift($this->buffer);
     }
 
     /**

--- a/tests/Entity/MessageManagerTest.php
+++ b/tests/Entity/MessageManagerTest.php
@@ -151,6 +151,21 @@ class MessageManagerTest extends TestCase
             ->getPager(['state' => MessageInterface::STATE_IN_PROGRESS], 1);
     }
 
+    public function testFindByTypes(): void
+    {
+        $this
+            ->getMessageManager(function ($qb): void {
+                $qb->expects($this->never())->method('andWhere');
+                $qb->expects($this->once())->method('where')->willReturnSelf();
+                $qb->expects($this->once())->method('setParameters')
+                    ->with(['state' => MessageInterface::STATE_OPEN]);
+                $qb->expects($this->once())->method('orderBy')->with(
+                    $this->equalTo('m.createdAt')
+                )->willReturnSelf();
+            })
+            ->findByTypes([], MessageInterface::STATE_OPEN, 10);
+    }
+
     /**
      * @return MessageManagerMock
      */


### PR DESCRIPTION
## Subject

I found out that with `backend: sonata.notification.backend.doctrine`, messages are consumed in the wrong order for me that should be first in first consumed. It seems that combination of :
- https://github.com/sonata-project/SonataNotificationBundle/blob/ab45a8a50d5836c7919f52b8f290a4fc0c33794d/src/Entity/MessageManager.php#L209, without order implies 'ASC' by default so old message first in the query result
- https://github.com/sonata-project/SonataNotificationBundle/blob/ab45a8a50d5836c7919f52b8f290a4fc0c33794d/src/Iterator/MessageManagerMessageIterator.php#L126, array_pop will pop the element off the end of array which means newest message first

For me it should be a First In First Out, but i may be wrong :)

I am targeting this branch, because it's changing the order of message consumption and may have some unwanted side effects on existing projects.

## Changelog

```markdown
### Fixed
Fix order of message handling with doctrine backend (older first)
```