### PR TITLE
Update SwiftMailerConsumer.php

### DIFF
--- a/src/Consumer/SwiftMailerConsumer.php
+++ b/src/Consumer/SwiftMailerConsumer.php
@@ -67,6 +67,10 @@ class SwiftMailerConsumer implements ConsumerInterface
         if ($replyTo = $message->getValue('replyTo')) {
             $mail->setReplyTo($replyTo);
         }
+        
+        if ($returnPath = $message->getValue('returnPath')) {
+            $mail->setReturnPath($returnPath);
+        }
 
         if ($cc = $message->getValue('cc')) {
             $mail->setCc($cc);

--- a/src/Consumer/SwiftMailerConsumer.php
+++ b/src/Consumer/SwiftMailerConsumer.php
@@ -67,7 +67,6 @@ class SwiftMailerConsumer implements ConsumerInterface
         if ($replyTo = $message->getValue('replyTo')) {
             $mail->setReplyTo($replyTo);
         }
-        
         if ($returnPath = $message->getValue('returnPath')) {
             $mail->setReturnPath($returnPath);
         }

--- a/tests/Consumer/SwiftMailerConsumerTest.php
+++ b/tests/Consumer/SwiftMailerConsumerTest.php
@@ -61,6 +61,9 @@ class SwiftMailerConsumerTest extends TestCase
                 'replyTo1@mail.fr',
                 'replyTo2@mail.fr' => 'nameReplyTo2',
             ],
+            'returnPath' => [
+                'email' => 'returnPath@mail.fr',
+            ],
             'cc' => [
                 'cc1@mail.fr',
                 'cc2@mail.fr' => 'nameCc2',
@@ -84,6 +87,7 @@ class SwiftMailerConsumerTest extends TestCase
         $mail->expects($this->once())->method('setFrom')->with($this->equalTo(['from@mail.fr' => 'nameFrom']))->willReturnSelf();
         $mail->expects($this->once())->method('setTo')->with($this->equalTo(['to1@mail.fr', 'to2@mail.fr' => 'nameTo2']))->willReturnSelf();
         $mail->expects($this->once())->method('setReplyTo')->with($this->equalTo(['replyTo1@mail.fr', 'replyTo2@mail.fr' => 'nameReplyTo2']))->willReturnSelf();
+        $mail->expects($this->once())->method('setReturnPath')->with($this->equalTo(['email' => 'returnPath@mail.fr']))->willReturnSelf();
         $mail->expects($this->once())
             ->method('setCc')
             ->with($this->equalTo(['cc1@mail.fr', 'cc2@mail.fr' => 'nameCc2']))


### PR DESCRIPTION
Add ability to set the returnPath for mail messages sent via the notificationBundle

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the change is backward compatible and adds another email parameter setting option but does not affect if it is not submitted.

<!--
   
    fixes #363 
-->

Closes #363

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNotificationBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed

sendEmail function to allow for there setting of a return path 
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->