### PR TITLE
Update RestartCommand check count message only for not pulling mode

### DIFF
--- a/src/Command/RestartCommand.php
+++ b/src/Command/RestartCommand.php
@@ -67,12 +67,17 @@ class RestartCommand extends ContainerAwareCommand
                 $input->getOption('type'),
                 $input->getOption('max-attempts')
             );
-        }
 
-        if (0 === \count($messages)) {
-            $output->writeln('Nothing to restart, bye.');
+            /*
+             * Check messages count only for not pulling mode
+             * to avoid PHP warning message
+             * since ErroneousMessageIterator does not implement Countable.
+             */
+            if (0 === \count($messages)) {
+                $output->writeln('Nothing to restart, bye.');
 
-            return;
+                return;
+            }
         }
 
         $eventDispatcher = $this->getContainer()->get('event_dispatcher');


### PR DESCRIPTION
## Subject

When using restart command we always check `$messages` count, however in case of pulling mode `messages` is an instance of `ErroneousMessageIterator` witch does not implements `Countable` therefor we have a PHP warning message in our logs.
    
## Changelog

```markdown

### Changed

- Update RestartCommand check count message only for not pulling mode
```
