### PR TITLE
Update docs bis

### DIFF
--- a/docs/reference/usage.rst
+++ b/docs/reference/usage.rst
@@ -49,7 +49,6 @@ logger consumer creation::
     namespace Sonata\NotificationBundle\Consumer;
 
     use Sonata\NotificationBundle\Consumer\ConsumerInterface;
-    use Sonata\NotificationBundle\Exception\InvalidParameterException;
     use Sonata\NotificationBundle\Model\MessageInterface;
     use Symfony\Component\HttpKernel\Log\LoggerInterface;
 
@@ -78,7 +77,7 @@ logger consumer creation::
             $message = $event->getMessage();
 
             if (!in_array($message->getValue('level'), $this->types)) {
-                throw new InvalidParameterException();
+                throw new \RuntimeException();
             }
 
             call_user_func([$this->logger, $message->getValue('level')], $message->getValue('message'));

--- a/docs/reference/usage.rst
+++ b/docs/reference/usage.rst
@@ -77,7 +77,7 @@ logger consumer creation::
             $message = $event->getMessage();
 
             if (!in_array($message->getValue('level'), $this->types)) {
-                throw new \RuntimeException();
+                throw new \RuntimeException('Invalid parameter');
             }
 
             call_user_func([$this->logger, $message->getValue('level')], $message->getValue('message'));


### PR DESCRIPTION
sees https://github.com/sonata-project/SonataCoreBundle/pull/571

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Original PR:https://github.com/sonata-project/SonataNotificationBundle/pull/375
It seems there is no alternative to InvalidParameterException. In SonataNotificationBundle, the depreciation says to use the exception from SonataCoreBundle, but it'll be removed from SonataCoreBundle. 
I read https://github.com/sonata-project/SonataCoreBundle/pull/571.
So maybe remove this part of code from the docs.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it concerns the depreciation about 3.x.