### PR TITLE
Change DelayStrategy as a configuration option

### DIFF
--- a/src/Backend/AMQPBackendDispatcher.php
+++ b/src/Backend/AMQPBackendDispatcher.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\NotificationBundle\Backend;
 
+use Enqueue\AmqpTools\DelayStrategy;
 use Enqueue\AmqpTools\DelayStrategyAware;
-use Enqueue\AmqpTools\RabbitMqDlxDelayStrategy;
 use Guzzle\Http\Client as GuzzleClient;
 use Interop\Amqp\AmqpConnectionFactory;
 use Interop\Amqp\AmqpContext;
@@ -61,6 +61,11 @@ class AMQPBackendDispatcher extends QueueBackendDispatcher
      * @var AmqpContext
      */
     private $context;
+
+    /**
+     * @var DelayStrategy|null
+     */
+    private $delayStrategy;
 
     /**
      * @param array  $settings
@@ -133,7 +138,7 @@ class AMQPBackendDispatcher extends QueueBackendDispatcher
             ]);
 
             if ($factory instanceof DelayStrategyAware) {
-                $factory->setDelayStrategy(new RabbitMqDlxDelayStrategy());
+                $factory->setDelayStrategy($this->delayStrategy);
             }
 
             $this->context = $factory->createContext();
@@ -270,6 +275,11 @@ class AMQPBackendDispatcher extends QueueBackendDispatcher
      */
     public function initialize()
     {
+    }
+
+    public function setDelayStrategy(?DelayStrategy $delayStrategy): void
+    {
+        $this->delayStrategy = $delayStrategy;
     }
 
     /**

--- a/src/DependencyInjection/SonataNotificationExtension.php
+++ b/src/DependencyInjection/SonataNotificationExtension.php
@@ -416,6 +416,10 @@ class SonataNotificationExtension extends Extension
             throw new \RuntimeException('You need to specify a valid default queue for the rabbitmq backend!');
         }
 
+        if (class_exists('Enqueue\AmqpTools\RabbitMqDlxDelayStrategy')) {
+            $container->setDefinition('sonata.notification.backend.rabbitmq.delay_strategy', new Definition('Enqueue\AmqpTools\RabbitMqDlxDelayStrategy'));
+        }
+
         $container->getDefinition('sonata.notification.backend.rabbitmq')
             ->replaceArgument(0, $connection)
             ->replaceArgument(1, $queues)

--- a/src/Resources/config/backend.xml
+++ b/src/Resources/config/backend.xml
@@ -20,6 +20,9 @@
             <argument/>
             <argument/>
             <argument/>
+            <call method="setDelayStrategy">
+                <argument type="service" id="sonata.notification.backend.rabbitmq.delay_strategy" on-invalid="ignore"/>
+            </call>
         </service>
     </services>
 </container>


### PR DESCRIPTION
## Make it so that devs can override the DelayStrategy service in case that the project doesn't default to `RabbitMqDlxDelayStrategy`

I am targeting this branch, because we need to use a strategy other than `RabbitMqDlxDelayStrategy`. Right now this is possible with hacks via Relfection. I think it is a good idea to make this optional since you can also implement your own strategy entirely. It would also be beneficial to the community if they are not forced to use a default strategy just because SonataNotificationBundle has a hard-coded optional value. 

## Changelog

```markdown
### Changed
- `RabbitMqDlxDelayStrategy` is not assigned immediately if the `AmqpConnectionFactory` is of instance `DelayStrategyAware`. 
- If `RabbitMqDlxDelayStrategy` class is found a service is built with this class. 
- `AMPQBackendDispatcher` gets now the delay strategy as an optional dependency via `calls`. 
```
