### PR TITLE
remove deprecated corebundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "php": "^7.1",
         "doctrine/doctrine-bundle": "^1.12 || ^2.0",
         "doctrine/persistence": "^1.3",
-        "sonata-project/core-bundle": "^3.9",
         "sonata-project/datagrid-bundle": "^2.5",
         "sonata-project/doctrine-extensions": "^1.5",
         "symfony/config": "^4.4",


### PR DESCRIPTION
## Subject

Remove deprecated SonataCoreBundle

I am targeting 3.x, because there's no BC break.

Closes #423 

## Changelog

```markdown
### Fixed
- Fix SonataCoreBundle deprecations
```