### PR TITLE
Fix RestFul API

### DIFF
--- a/src/Resources/config/api_controllers.xml
+++ b/src/Resources/config/api_controllers.xml
@@ -5,5 +5,6 @@
             <argument type="service" id="sonata.notification.manager.message"/>
             <argument type="service" id="form.factory"/>
         </service>
+        <service id="Sonata\NotificationBundle\Controller\Api\MessageController" alias="sonata.notification.controller.api.message" public="true"/>
     </services>
 </container>

--- a/src/Resources/config/routing/api.xml
+++ b/src/Resources/config/routing/api.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://friendsofsymfony.github.com/schema/rest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://friendsofsymfony.github.com/schema/rest https://raw.github.com/FriendsOfSymfony/FOSRestBundle/master/Resources/config/schema/routing/rest_routing-1.0.xsd">
-    <import type="rest" resource="sonata.notification.controller.api.message" name-prefix="sonata_api_notification_message_"/>
+    <import type="rest" resource="Sonata\NotificationBundle\Controller\Api\MessageController" name-prefix="sonata_api_notification_message_"/>
 </routes>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Part of https://github.com/sonata-project/dev-kit/issues/778

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataClassificationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added public alias `Sonata\NotificationBundle\Controller\Api\MessageController` for `sonata.notification.controller.api.message` service
### Fixed
- fix RestFul API - `Class could not be determined for Controller identified` Error
```
<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
