### PR TITLE
Make SonataEasyExtends optional

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,12 +1,20 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.x to 3.x
+=======================
+
+### SonataEasyExtends is deprecated
+
+Registering `SonataEasyExtendsBundle` bundle is deprecated, it SHOULD NOT be registered.
+Register `SonataDoctrineBundle` bundle instead.
+
 UPGRADE FROM 3.2 to 3.3
 =======================
 
 ### AMQP
 
-You might face some issues (though we tried to keep everything BC) if you are extending `AMQPBackend`, `AMQPBackendDispatcher` or `AMQPMessageIterator` classes 
+You might face some issues (though we tried to keep everything BC) if you are extending `AMQPBackend`, `AMQPBackendDispatcher` or `AMQPMessageIterator` classes
 or rely on their `__construct` method signature.
 
 If you want to migrate to another amqp interop compatible transport, say `enqueue/amqp-ext`, the BC layer want work and the exception is thrown.
@@ -16,6 +24,6 @@ UPGRADE FROM 3.0 to 3.1
 
 ### Tests
 
-All files under the ``Tests`` directory are now correctly handled as internal test classes. 
-You can't extend them anymore, because they are only loaded when running internal tests. 
+All files under the ``Tests`` directory are now correctly handled as internal test classes.
+You can't extend them anymore, because they are only loaded when running internal tests.
 More information can be found in the [composer docs](https://getcomposer.org/doc/04-schema.md#autoload-dev).

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,9 @@
         "php": "^7.2",
         "doctrine/doctrine-bundle": "^1.12 || ^2.0",
         "doctrine/persistence": "^1.3",
+        "laminas/laminas-diagnostics": "^1.6",
         "sonata-project/datagrid-bundle": "^2.5",
-        "sonata-project/doctrine-extensions": "^1.5",
+        "sonata-project/doctrine-extensions": "^1.8",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4",
         "symfony/console": "^4.4",
@@ -36,8 +37,7 @@
         "symfony/form": "^4.4",
         "symfony/http-foundation": "^4.4",
         "symfony/http-kernel": "^4.4",
-        "symfony/security-core": "^4.4",
-        "zendframework/zenddiagnostics": "^1.0"
+        "symfony/security-core": "^4.4"
     },
     "conflict": {
         "friendsofsymfony/rest-bundle": "<2.1",
@@ -51,6 +51,8 @@
         "guzzlehttp/guzzle": "^3.8",
         "jms/serializer-bundle": "^2.0 || ^3.0",
         "liip/monitor-bundle": "^2.6",
+        "matthiasnoback/symfony-config-test": "^4.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "nelmio/api-doc-bundle": "^2.13",
         "sensio/framework-extra-bundle": "^5.5",
         "sonata-project/doctrine-orm-admin-bundle": "^3.19",

--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -90,15 +90,15 @@ Full configuration options:
             # Iterate event is thrown on each command iteration
             #
             # Iteration listener class must implement Sonata\NotificationBundle\Event\IterationListener
-            iteration_listeners:  []
+            iteration_listeners: []
             class:
-                message:              App\Entity\Message
+                message: App\Entity\SonataNotificationMessage
             admin:
-                enabled:              true
+                enabled: true
                 message:
-                    class:                Sonata\NotificationBundle\Admin\MessageAdmin
-                    controller:           'SonataNotificationBundle:MessageAdmin'
-                    translation:          SonataNotificationBundle
+                    class: Sonata\NotificationBundle\Admin\MessageAdmin
+                    controller: 'SonataNotificationBundle:MessageAdmin'
+                    translation: SonataNotificationBundle
 
     .. code-block:: yaml
 

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -1,25 +1,60 @@
+.. index::
+    single: Installation
+    single: Configuration
+
 Installation
 ============
 
-.. code-block:: bash
+Prerequisites
+-------------
+
+PHP ^7.2 and Symfony ^4.4 are needed to make this bundle work, there are
+also some Sonata dependencies that need to be installed and configured beforehand.
+
+Optional dependencies:
+
+* `SonataAdminBundle <https://sonata-project.org/bundles/admin>`_
+
+And the persistence bundle (currently, not all the implementations of the Sonata persistence bundles are available):
+
+* `SonataDoctrineOrmAdminBundle <https://sonata-project.org/bundles/doctrine-orm-admin>`_
+
+Follow also their configuration step; you will find everything you need in
+their own installation chapter.
+
+.. note::
+
+    If a dependency is already installed somewhere in your project or in
+    another dependency, you won't need to install it again.
+
+Install Symfony Flex packs
+--------------------------
+
+With this method you can directly setup all the entities required to make this bundle work
+with the different persistence bundles supported.
+
+If you picked ``SonataDoctrineOrmAdminBundle``, install the Sonata Media ORM pack::
+
+    composer require sonata-project/notification-orm-pack
+
+Install without Symfony Flex packs
+----------------------------------
+
+Add ``SonataNotificationBundle`` via composer::
 
     composer require sonata-project/notification-bundle
 
-Or if you wish to use doctrine backend, execute ``composer require sonata-project/notification-orm-pack``.
-Symfony Flex will download recipes and install all necessary configuration
-files and an entity class for notification messages.
+If you want to use the REST API, you also need ``friendsofsymfony/rest-bundle`` and ``nelmio/api-doc-bundle``::
 
-Next, add the dependent bundles:
+    composer require friendsofsymfony/rest-bundle nelmio/api-doc-bundle
 
-.. code-block:: bash
+There are other optional dependencies::
 
-    composer require enqueue/amqp-lib --no-update # optional
-    composer require liip/monitor-bundle --no-update # optional
-    composer require friendsofsymfony/rest-bundle  --no-update # optional when using api with doctrine backend
-    composer require nelmio/api-doc-bundle  --no-update # optional when using api with doctrine backend
-    composer update
+    composer require enqueue/amqp-lib
+    composer require liip/monitor-bundle
 
-Now, add the new ``SonataNotificationBundle`` Bundle to ``bundles.php`` file::
+Next, be sure to enable the bundles in your ``config/bundles.php`` file if they
+are not already enabled::
 
     // config/bundles.php
 
@@ -29,10 +64,10 @@ Now, add the new ``SonataNotificationBundle`` Bundle to ``bundles.php`` file::
     ];
 
 Configuration
--------------
+=============
 
 SonataNotificationBundle Configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------
 
 To use the ``SonataNotificationBundle``, add the following lines to your application configuration
 file.
@@ -61,12 +96,10 @@ You can disable the admin if you don't need it :
         admin:
             enabled: false
 
-Doctrine Configuration
-~~~~~~~~~~~~~~~~~~~~~~
+Doctrine ORM Configuration
+--------------------------
 
-Add this bundle in the config mapping definition (or enable `auto_mapping`_):
-
-.. code-block:: yaml
+Add the bundle in the config mapping definition (or enable `auto_mapping`_)::
 
     # config/packages/doctrine.yaml
 
@@ -77,8 +110,42 @@ Add this bundle in the config mapping definition (or enable `auto_mapping`_):
                     mappings:
                         SonataNotificationBundle: ~
 
-        dbal:
-            types:
-                json: Sonata\Doctrine\Types\JsonType
+And then create the corresponding entity, ``src/Entity/SonataNotificationMessage``::
 
-.. _`auto_mapping`: http://symfony.com/doc/2.0/reference/configuration/doctrine.html#configuration-overview
+    // src/Entity/SonataNotificationMessage.php
+
+    use Doctrine\ORM\Mapping as ORM;
+    use Sonata\NotificationBundle\Entity\BaseMessage;
+
+    /**
+     * @ORM\Entity
+     * @ORM\Table(name="notification__message")
+     */
+    class SonataNotificationMessage extends BaseMessage
+    {
+        /**
+         * @ORM\Id
+         * @ORM\GeneratedValue
+         * @ORM\Column(type="integer")
+         */
+        protected $id;
+    }
+
+The only thing left is to update your schema::
+
+    bin/console doctrine:schema:update --force
+
+Next Steps
+----------
+
+At this point, your Symfony installation should be fully functional, without errors
+showing up from SonataNotificationBundle. If, at this point or during the installation,
+you come across any errors, don't panic:
+
+    - Read the error message carefully. Try to find out exactly which bundle is causing the error.
+      Is it SonataNotificationBundle or one of the dependencies?
+    - Make sure you followed all the instructions correctly, for both SonataNotificationBundle and its dependencies.
+    - Still no luck? Try checking the project's `open issues on GitHub`_.
+
+.. _`open issues on GitHub`: https://github.com/sonata-project/SonataNotificationBundle/issues
+.. _`auto_mapping`: http://symfony.com/doc/4.4/reference/configuration/doctrine.html#configuration-overviews

--- a/src/Backend/AMQPBackend.php
+++ b/src/Backend/AMQPBackend.php
@@ -19,6 +19,8 @@ use Interop\Amqp\AmqpMessage;
 use Interop\Amqp\AmqpQueue;
 use Interop\Amqp\AmqpTopic;
 use Interop\Amqp\Impl\AmqpBind;
+use Laminas\Diagnostics\Result\Failure;
+use Laminas\Diagnostics\Result\Success;
 use PhpAmqpLib\Channel\AMQPChannel;
 use Sonata\NotificationBundle\Consumer\ConsumerEvent;
 use Sonata\NotificationBundle\Exception\HandlingException;
@@ -26,8 +28,6 @@ use Sonata\NotificationBundle\Iterator\AMQPMessageIterator;
 use Sonata\NotificationBundle\Model\Message;
 use Sonata\NotificationBundle\Model\MessageInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use ZendDiagnostics\Result\Failure;
-use ZendDiagnostics\Result\Success;
 
 /**
  * Consumer side of the rabbitMQ backend.

--- a/src/Backend/AMQPBackendDispatcher.php
+++ b/src/Backend/AMQPBackendDispatcher.php
@@ -18,13 +18,13 @@ use Enqueue\AmqpTools\RabbitMqDlxDelayStrategy;
 use Guzzle\Http\Client as GuzzleClient;
 use Interop\Amqp\AmqpConnectionFactory;
 use Interop\Amqp\AmqpContext;
+use Laminas\Diagnostics\Result\Failure;
+use Laminas\Diagnostics\Result\Success;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AMQPConnection;
 use Sonata\NotificationBundle\Exception\BackendNotFoundException;
 use Sonata\NotificationBundle\Model\MessageInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use ZendDiagnostics\Result\Failure;
-use ZendDiagnostics\Result\Success;
 
 /**
  * Producer side of the rabbitmq backend.

--- a/src/Backend/BackendHealthCheck.php
+++ b/src/Backend/BackendHealthCheck.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\NotificationBundle\Backend;
 
-use ZendDiagnostics\Check\AbstractCheck;
+use Laminas\Diagnostics\Check\AbstractCheck;
 
 class BackendHealthCheck extends AbstractCheck
 {

--- a/src/Backend/BackendInterface.php
+++ b/src/Backend/BackendInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\NotificationBundle\Backend;
 
+use Laminas\Diagnostics\Result\ResultInterface;
 use Sonata\NotificationBundle\Model\MessageInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use ZendDiagnostics\Result\ResultInterface;
 
 interface BackendInterface
 {

--- a/src/Backend/MessageManagerBackend.php
+++ b/src/Backend/MessageManagerBackend.php
@@ -13,15 +13,15 @@ declare(strict_types=1);
 
 namespace Sonata\NotificationBundle\Backend;
 
+use Laminas\Diagnostics\Result\Failure;
+use Laminas\Diagnostics\Result\Success;
+use Laminas\Diagnostics\Result\Warning;
 use Sonata\NotificationBundle\Consumer\ConsumerEvent;
 use Sonata\NotificationBundle\Exception\HandlingException;
 use Sonata\NotificationBundle\Iterator\MessageManagerMessageIterator;
 use Sonata\NotificationBundle\Model\MessageInterface;
 use Sonata\NotificationBundle\Model\MessageManagerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use ZendDiagnostics\Result\Failure;
-use ZendDiagnostics\Result\Success;
-use ZendDiagnostics\Result\Warning;
 
 class MessageManagerBackend implements BackendInterface
 {

--- a/src/Backend/MessageManagerBackendDispatcher.php
+++ b/src/Backend/MessageManagerBackendDispatcher.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sonata\NotificationBundle\Backend;
 
+use Laminas\Diagnostics\Result\Success;
 use Sonata\NotificationBundle\Model\MessageInterface;
 use Sonata\NotificationBundle\Model\MessageManagerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use ZendDiagnostics\Result\Success;
 
 /**
  * Producer side of the doctrine backend.

--- a/src/Backend/PostponeRuntimeBackend.php
+++ b/src/Backend/PostponeRuntimeBackend.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace Sonata\NotificationBundle\Backend;
 
+use Laminas\Diagnostics\Result\Success;
 use Sonata\NotificationBundle\Iterator\IteratorProxyMessageIterator;
 use Sonata\NotificationBundle\Model\MessageInterface;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use ZendDiagnostics\Result\Success;
 
 /**
  * This backend postpones the handling of messages to a registered event.

--- a/src/Backend/RuntimeBackend.php
+++ b/src/Backend/RuntimeBackend.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Sonata\NotificationBundle\Backend;
 
+use Laminas\Diagnostics\Result\Success;
 use Sonata\NotificationBundle\Consumer\ConsumerEvent;
 use Sonata\NotificationBundle\Exception\HandlingException;
 use Sonata\NotificationBundle\Model\Message;
 use Sonata\NotificationBundle\Model\MessageInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use ZendDiagnostics\Result\Success;
 
 class RuntimeBackend implements BackendInterface
 {

--- a/src/DependencyInjection/SonataNotificationExtension.php
+++ b/src/DependencyInjection/SonataNotificationExtension.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\NotificationBundle\DependencyInjection;
 
 use Sonata\Doctrine\Mapper\DoctrineCollector;
+use Sonata\EasyExtendsBundle\Mapper\DoctrineCollector as DeprecatedDoctrineCollector;
 use Sonata\NotificationBundle\Backend\AMQPBackend;
 use Sonata\NotificationBundle\Backend\MessageManagerBackend;
 use Sonata\NotificationBundle\Model\MessageInterface;
@@ -78,7 +79,13 @@ class SonataNotificationExtension extends Extension
         $container->setAlias('sonata.notification.backend', $config['backend'])->setPublic(true);
         $container->setParameter('sonata.notification.backend', $config['backend']);
 
-        $this->registerDoctrineMapping($config);
+        if (isset($bundles['SonataDoctrineBundle'])) {
+            $this->registerSonataDoctrineMapping($config);
+        } else {
+            // NEXT MAJOR: Remove next line and throw error when not registering SonataDoctrineBundle
+            $this->registerDoctrineMapping($config);
+        }
+
         $this->registerParameters($container, $config);
         $this->configureBackends($container, $config);
         $this->configureClass($container, $config);
@@ -149,9 +156,17 @@ class SonataNotificationExtension extends Extension
         }
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function registerDoctrineMapping(array $config)
     {
-        $collector = DoctrineCollector::getInstance();
+        @trigger_error(
+            'Using SonataEasyExtendsBundle is deprecated since sonata-project/notification-bundle 3.x. Please register SonataDoctrineBundle as a bundle instead.',
+            E_USER_DEPRECATED
+        );
+
+        $collector = DeprecatedDoctrineCollector::getInstance();
 
         $collector->addIndex($config['class']['message'], 'idx_state', [
             'state',
@@ -425,6 +440,14 @@ class SonataNotificationExtension extends Extension
         $container->setDefinition($id, $definition);
 
         return $id;
+    }
+
+    private function registerSonataDoctrineMapping(array $config): void
+    {
+        $collector = DoctrineCollector::getInstance();
+
+        $collector->addIndex($config['class']['message'], 'idx_state', ['state']);
+        $collector->addIndex($config['class']['message'], 'idx_created_at', ['created_at']);
     }
 
     /**

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -17,6 +17,7 @@ use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use FOS\RestBundle\FOSRestBundle;
 use JMS\SerializerBundle\JMSSerializerBundle;
 use Nelmio\ApiDocBundle\NelmioApiDocBundle;
+use Sonata\Doctrine\Bridge\Symfony\SonataDoctrineBundle;
 use Sonata\NotificationBundle\SonataNotificationBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
@@ -43,6 +44,7 @@ final class AppKernel extends Kernel
             new SecurityBundle(),
             new TwigBundle(),
             new FOSRestBundle(),
+            new SonataDoctrineBundle(),
             new SonataNotificationBundle(),
             new JMSSerializerBundle(),
             new DoctrineBundle(),

--- a/tests/Backend/BackendHealthCheckTest.php
+++ b/tests/Backend/BackendHealthCheckTest.php
@@ -13,20 +13,13 @@ declare(strict_types=1);
 
 namespace Sonata\NotificationBundle\Tests\Notification;
 
+use Laminas\Diagnostics\Result\Success;
 use PHPUnit\Framework\TestCase;
 use Sonata\NotificationBundle\Backend\BackendHealthCheck;
 use Sonata\NotificationBundle\Backend\BackendInterface;
-use ZendDiagnostics\Result\Success;
 
 class BackendHealthCheckTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        if (!class_exists(Success::class)) {
-            $this->markTestSkipped('ZendDiagnostics\Result\Success does not exist');
-        }
-    }
-
     public function testCheck(): void
     {
         $result = new Success('Test check', 'OK');

--- a/tests/Backend/MessageManagerBackendTest.php
+++ b/tests/Backend/MessageManagerBackendTest.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\NotificationBundle\Tests\Notification;
 
+use Laminas\Diagnostics\Result\Failure;
+use Laminas\Diagnostics\Result\Success;
+use Laminas\Diagnostics\Result\Warning;
 use PHPUnit\Framework\TestCase;
 use Sonata\NotificationBundle\Backend\MessageManagerBackend;
 use Sonata\NotificationBundle\Exception\HandlingException;
@@ -20,9 +23,6 @@ use Sonata\NotificationBundle\Model\MessageInterface;
 use Sonata\NotificationBundle\Model\MessageManagerInterface;
 use Sonata\NotificationBundle\Tests\Entity\Message;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use ZendDiagnostics\Result\Failure;
-use ZendDiagnostics\Result\Success;
-use ZendDiagnostics\Result\Warning;
 
 class MessageManagerBackendTest extends TestCase
 {
@@ -90,10 +90,6 @@ class MessageManagerBackendTest extends TestCase
      */
     public function testStatus($counts, $expectedStatus, $message): void
     {
-        if (!class_exists(Success::class)) {
-            $this->markTestSkipped('The class ZendDiagnostics\Result\Success does not exist');
-        }
-
         $modelManager = $this->createMock(MessageManagerInterface::class);
         $modelManager->expects($this->once())->method('countStates')->willReturn($counts);
 

--- a/tests/Backend/PostponeRuntimeBackendTest.php
+++ b/tests/Backend/PostponeRuntimeBackendTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\NotificationBundle\Tests\Backend;
 
+use Laminas\Diagnostics\Result\Success;
 use PHPUnit\Framework\TestCase;
 use Sonata\NotificationBundle\Backend\PostponeRuntimeBackend;
 use Sonata\NotificationBundle\Consumer\ConsumerEventInterface;
@@ -20,7 +21,6 @@ use Sonata\NotificationBundle\Model\MessageInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
-use ZendDiagnostics\Result\Success;
 
 /**
  * @covers \Sonata\NotificationBundle\Backend\PostponeRuntimeBackend
@@ -137,10 +137,6 @@ class PostponeRuntimeBackendTest extends TestCase
 
     public function testStatusIsOk(): void
     {
-        if (!class_exists(Success::class)) {
-            $this->markTestSkipped('The class ZendDiagnostics\Result\Success does not exist');
-        }
-
         $backend = new PostponeRuntimeBackend(
             $this->createMock(EventDispatcherInterface::class),
             true

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NotificationBundle\Tests\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionConfigurationTestCase;
+use Sonata\NotificationBundle\Admin\MessageAdmin;
+use Sonata\NotificationBundle\DependencyInjection\Configuration;
+use Sonata\NotificationBundle\DependencyInjection\SonataNotificationExtension;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+
+final class ConfigurationTest extends AbstractExtensionConfigurationTestCase
+{
+    public function testDefault(): void
+    {
+        $this->assertProcessedConfigurationEquals([
+            'backend' => 'sonata.notification.backend.runtime',
+            'queues' => [],
+            'consumers' => [
+                'register_default' => true,
+            ],
+            'iteration_listeners' => [],
+            'class' => [
+                'message' => 'App\Entity\Message',
+            ],
+            'admin' => [
+                'enabled' => true,
+                'message' => [
+                    'class' => MessageAdmin::class,
+                    'controller' => 'SonataNotificationBundle:MessageAdmin',
+                    'translation' => 'SonataNotificationBundle',
+                ],
+            ],
+        ], [
+            __DIR__.'/../Fixtures/configuration.yaml',
+        ]);
+    }
+
+    protected function getContainerExtension(): ExtensionInterface
+    {
+        return new SonataNotificationExtension();
+    }
+
+    protected function getConfiguration(): ConfigurationInterface
+    {
+        return new Configuration();
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataArticleBundle/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

Part of: https://github.com/sonata-project/dev-kit/issues/750

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

SonataEasyExtends is deprecated but it is used on many bundles, this makes it optional. This change is BC because if the user does not change anything it will continue using the deprecated code but with a message.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataArticleBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- SonataEasyExtendsBundle is now optional, using SonataDoctrineBundle is preferred
- Use Laminas instead of deprecated Zend
### Deprecated
- Using SonataEasyExtendsBundle to add Doctrine mapping information
```

## To do

- [x] Update the documentation;
- [x] Add an upgrade note.
