### PR TITLE
Use XML for ReST API routing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,25 +40,26 @@
         "symfony/security-core": "^4.4"
     },
     "conflict": {
-        "friendsofsymfony/rest-bundle": "<2.1",
+        "friendsofsymfony/rest-bundle": "<2.3",
         "jms/serializer": "<0.13",
         "sonata-project/admin-bundle": "<3.1",
         "sonata-project/core-bundle": "<3.20"
     },
     "require-dev": {
         "enqueue/amqp-lib": "^0.8",
-        "friendsofsymfony/rest-bundle": "^2.1 || ^3.0",
+        "friendsofsymfony/rest-bundle": "^2.3 || ^3.0",
         "guzzlehttp/guzzle": "^3.8",
         "jms/serializer-bundle": "^2.0 || ^3.0",
         "liip/monitor-bundle": "^2.6",
         "matthiasnoback/symfony-config-test": "^4.0",
-        "matthiasnoback/symfony-dependency-injection-test": "^4.0",
-        "nelmio/api-doc-bundle": "^2.13",
-        "sensio/framework-extra-bundle": "^5.5",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.1",
+        "nelmio/api-doc-bundle": "^2.13.4",
         "sonata-project/doctrine-orm-admin-bundle": "^3.19",
         "swiftmailer/swiftmailer": "^5.0 || ^6.0",
         "symfony/browser-kit": "^4.4 || ^5.1",
         "symfony/phpunit-bridge": "^5.1",
+        "symfony/swiftmailer-bundle": "^3.4",
+        "symfony/templating": "^4.4",
         "symfony/yaml": "^4.4"
     },
     "suggest": {

--- a/src/Controller/Api/MessageController.php
+++ b/src/Controller/Api/MessageController.php
@@ -21,12 +21,9 @@ use Sonata\NotificationBundle\Model\MessageInterface;
 use Sonata\NotificationBundle\Model\MessageManagerInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
- *
- * @Route(defaults={"_format": "json"}, requirements={"_format": "json|xml|html"})
  */
 class MessageController
 {
@@ -53,8 +50,6 @@ class MessageController
      *  resource=true,
      *  output={"class"="Sonata\DatagridBundle\Pager\PagerInterface", "groups"={"sonata_api_read"}}
      * )
-     *
-     * @Rest\Get("/messages.{_format}", name="get_messages")
      *
      * @Rest\QueryParam(name="page", requirements="\d+", default="1", description="Page for message list pagination")
      * @Rest\QueryParam(name="count", requirements="\d+", default="10", description="Number of messages by page")
@@ -104,8 +99,6 @@ class MessageController
      *      400="Returned when an error has occurred while message creation"
      *  }
      * )
-     *
-     * @Rest\Post("/messages.{_format}", name="post_message")
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *

--- a/src/Resources/config/routing/api.xml
+++ b/src/Resources/config/routing/api.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
-    <import type="annotation" resource="Sonata\NotificationBundle\Controller\Api\MessageController" name-prefix="sonata_api_notification_message_"/>
+    <route id="sonata_api_notification_message_get_messages" path="/messages.{_format}" methods="GET" controller="Sonata\NotificationBundle\Controller\Api\MessageController::getMessagesAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="sonata_api_notification_message_post_message" path="/messages.{_format}" methods="POST" controller="Sonata\NotificationBundle\Controller\Api\MessageController::postMessageAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
 </routes>

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -18,10 +18,12 @@ use FOS\RestBundle\FOSRestBundle;
 use JMS\SerializerBundle\JMSSerializerBundle;
 use Nelmio\ApiDocBundle\NelmioApiDocBundle;
 use Sonata\Doctrine\Bridge\Symfony\SonataDoctrineBundle;
+use Sonata\Form\Bridge\Symfony\SonataFormBundle;
 use Sonata\NotificationBundle\SonataNotificationBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
+use Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -49,6 +51,8 @@ final class AppKernel extends Kernel
             new JMSSerializerBundle(),
             new DoctrineBundle(),
             new NelmioApiDocBundle(),
+            new SwiftmailerBundle(),
+            new SonataFormBundle(),
         ];
     }
 
@@ -74,59 +78,10 @@ final class AppKernel extends Kernel
 
     protected function configureContainer(ContainerBuilder $containerBuilder, LoaderInterface $loader): void
     {
-        $containerBuilder->register('templating')->setSynthetic(true);
-        $containerBuilder->register('templating.locator')->setSynthetic(true);
-        $containerBuilder->register('templating.name_parser')->setSynthetic(true);
-        $containerBuilder->register('mailer')->setSynthetic(true);
+        $loader->load(__DIR__.'/config/config.yml');
+        $loader->load(__DIR__.'/config/security.yml');
 
-        $containerBuilder->loadFromExtension('framework', [
-            'secret' => '50n474.U53r',
-            'session' => [
-                'handler_id' => 'session.handler.native_file',
-                'storage_id' => 'session.storage.mock_file',
-                'name' => 'MOCKSESSID',
-            ],
-            'translator' => null,
-            'validation' => [
-                'enabled' => true,
-            ],
-            'form' => [
-                'enabled' => true,
-            ],
-            'assets' => null,
-            'test' => true,
-            'profiler' => [
-                'enabled' => true,
-                'collect' => false,
-            ],
-        ]);
-
-        $containerBuilder->loadFromExtension('security', [
-            'firewalls' => ['api' => ['anonymous' => true]],
-            'providers' => ['in_memory' => ['memory' => null]],
-        ]);
-
-        $containerBuilder->loadFromExtension('twig', [
-            'strict_variables' => '%kernel.debug%',
-            'exception_controller' => null,
-        ]);
-
-        $containerBuilder->loadFromExtension('doctrine', [
-            'dbal' => [
-                'connections' => [
-                    'default' => [
-                        'driver' => 'pdo_sqlite',
-                    ],
-                ],
-            ],
-            'orm' => [
-                'default_entity_manager' => 'default',
-            ],
-        ]);
-
-        $containerBuilder->loadFromExtension('fos_rest', [
-            'param_fetcher_listener' => true,
-        ]);
+        $containerBuilder->setParameter('app.base_dir', $this->getBaseDir());
     }
 
     private function getBaseDir(): string

--- a/tests/App/Entity/Message.php
+++ b/tests/App/Entity/Message.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NotificationBundle\Tests\App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Sonata\NotificationBundle\Entity\BaseMessage;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="notification__message")
+ */
+class Message extends BaseMessage
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    protected $id;
+}

--- a/tests/App/config/config.yml
+++ b/tests/App/config/config.yml
@@ -1,0 +1,45 @@
+framework:
+    test: true
+    secret: '50n474.U53r'
+    form:
+        enabled: true
+    translator:
+        enabled: true
+    session:
+        handler_id: session.handler.native_file
+        storage_id: session.storage.mock_file
+        name: MOCKSESSID
+    profiler:
+        enabled: true
+        collect: false
+
+twig:
+    exception_controller: null
+    paths:
+        - '%kernel.project_dir%/templates'
+    strict_variables: '%kernel.debug%'
+
+fos_rest:
+    param_fetcher_listener: true
+    body_listener: true
+    format_listener: true
+    view:
+        view_response_listener: force
+    body_converter:
+        enabled: false
+        validate: true
+
+doctrine:
+    dbal:
+        driver: pdo_sqlite
+        path: '%app.base_dir%sonata_notification_test.db3'
+    orm:
+        entity_managers:
+            default:
+                mappings:
+                    SonataNotificationBundle: ~
+                    SonataNotificationTest:
+                        type: annotation
+                        dir: '%kernel.project_dir%/Entity'
+                        is_bundle: false
+                        prefix: Sonata\NotificationBundle\Tests\App\Entity

--- a/tests/App/config/security.yml
+++ b/tests/App/config/security.yml
@@ -1,0 +1,13 @@
+security:
+    role_hierarchy: ~
+
+    providers:
+        in_memory:
+            memory:
+                users: ~
+
+    firewalls:
+        test:
+            security: false
+
+    access_control: ~


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Use XML for ReST API routing.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to https://github.com/sonata-project/SonataMediaBundle/pull/1767#discussion_r460857425.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNotificationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Change
- support for deprecated "rest" routing type in favor for xml
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
