### PR TITLE
Bump sonata-project/datagrid-bundle version

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,13 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.x to 3.x
+=======================
+
+### Upgrade to SonataDatagridBundle 3.0
+
+There is a minimal BC Break on `MessageManager::getPager`. If you are extending this method you should add parameter and return type hints.
+
 UPGRADE FROM 3.8 to 3.9
 =======================
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "doctrine/doctrine-bundle": "^1.12 || ^2.0",
         "doctrine/persistence": "^1.3",
         "laminas/laminas-diagnostics": "^1.6",
-        "sonata-project/datagrid-bundle": "^2.5",
+        "sonata-project/datagrid-bundle": "^3.0",
         "sonata-project/doctrine-extensions": "^1.8",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4",

--- a/src/Entity/MessageManager.php
+++ b/src/Entity/MessageManager.php
@@ -15,7 +15,7 @@ namespace Sonata\NotificationBundle\Entity;
 
 use Doctrine\ORM\QueryBuilder;
 use Sonata\DatagridBundle\Pager\Doctrine\Pager;
-use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
+use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\Doctrine\Entity\BaseEntityManager;
 use Sonata\NotificationBundle\Model\MessageInterface;
 use Sonata\NotificationBundle\Model\MessageManagerInterface;
@@ -151,7 +151,7 @@ class MessageManager extends BaseEntityManager implements MessageManagerInterfac
     /**
      * {@inheritdoc}
      */
-    public function getPager(array $criteria, $page, $limit = 10, array $sort = [])
+    public function getPager(array $criteria, int $page, int $limit = 10, array $sort = []): PagerInterface
     {
         $query = $this->getRepository()
             ->createQueryBuilder('m')
@@ -183,14 +183,8 @@ class MessageManager extends BaseEntityManager implements MessageManagerInterfac
         }
 
         $query->setParameters($parameters);
-        $pager = new Pager();
 
-        $pager->setMaxPerPage($limit);
-        $pager->setQuery(new ProxyQuery($query));
-        $pager->setPage($page);
-        $pager->init();
-
-        return $pager;
+        return Pager::create($query, $limit, $page);
     }
 
     /**

--- a/tests/Entity/MessageManagerTest.php
+++ b/tests/Entity/MessageManagerTest.php
@@ -166,9 +166,10 @@ class MessageManagerTest extends TestCase
             false,
             true,
             true,
-            ['execute']
+            ['execute', 'getSingleScalarResult']
         );
         $query->method('execute')->willReturn(true);
+        $query->method('getSingleScalarResult')->willReturn(1);
 
         $qb = $this->getMockBuilder(QueryBuilder::class)
             ->setConstructorArgs([$this->createMock(EntityManager::class)])


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Bump datagrid version. This is the last bundle that is using the 2.x release.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC. There is an signature change in the `MessageManager::getPager` method, but this is due to the new datagrid version.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNotificationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Bump `sonata-project/datagrid-bundle` version

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
