### PR TITLE
♻️  Replace ContainerAwareCommand usage by DI

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -20,3 +20,7 @@ UPGRADE FROM 3.x to 4.0
 ### Configuration
 
 * `sonata_notification.admin.enabled` is not enabled by default
+
+### Commands
+
+All commands now extend `Symfony\Component\Console\Command\Command` class instead of the deprecated `Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand` class.

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     ],
     "require": {
         "php": "^7.3",
+        "ext-json": "*",
         "doctrine/doctrine-bundle": "^1.12 || ^2.0",
         "doctrine/persistence": "^1.3 || ^2.0",
         "laminas/laminas-diagnostics": "^1.6",

--- a/src/Backend/BackendInterface.php
+++ b/src/Backend/BackendInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\NotificationBundle\Backend;
 
 use Laminas\Diagnostics\Result\ResultInterface;
+use Sonata\NotificationBundle\Iterator\MessageIteratorInterface;
 use Sonata\NotificationBundle\Model\MessageInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 

--- a/src/Command/CleanupCommand.php
+++ b/src/Command/CleanupCommand.php
@@ -13,13 +13,26 @@ declare(strict_types=1);
 
 namespace Sonata\NotificationBundle\Command;
 
+use Sonata\NotificationBundle\Backend\BackendInterface;
 use Sonata\NotificationBundle\Backend\QueueDispatcherInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CleanupCommand extends ContainerAwareCommand
+class CleanupCommand extends Command
 {
+    /**
+     * @var BackendInterface
+     */
+    private $backend;
+
+    public function __construct(
+        BackendInterface $backend
+    ) {
+        parent::__construct(null);
+        $this->backend = $backend;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -46,12 +59,10 @@ class CleanupCommand extends ContainerAwareCommand
      */
     private function getBackend()
     {
-        $backend = $this->getContainer()->get('sonata.notification.backend');
-
-        if ($backend instanceof QueueDispatcherInterface) {
-            return $backend->getBackend(null);
+        if ($this->backend instanceof QueueDispatcherInterface) {
+            return $this->backend->getBackend(null);
         }
 
-        return $backend;
+        return $this->backend;
     }
 }

--- a/src/Command/CreateAndPublishCommand.php
+++ b/src/Command/CreateAndPublishCommand.php
@@ -13,13 +13,26 @@ declare(strict_types=1);
 
 namespace Sonata\NotificationBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Sonata\NotificationBundle\Backend\BackendInterface;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CreateAndPublishCommand extends ContainerAwareCommand
+class CreateAndPublishCommand extends Command
 {
+    /**
+     * @var BackendInterface
+     */
+    private $backend;
+
+    public function __construct(BackendInterface $backend)
+    {
+        parent::__construct(null);
+
+        $this->backend = $backend;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -43,10 +56,7 @@ class CreateAndPublishCommand extends ContainerAwareCommand
             throw new \InvalidArgumentException('Body does not contain valid json.');
         }
 
-        $this->getContainer()
-            ->get('sonata.notification.backend')
-            ->createAndPublish($type, $body)
-        ;
+        $this->backend->createAndPublish($type, $body);
 
         $output->writeln('<info>Done !</info>');
     }

--- a/src/Command/ListHandlerCommand.php
+++ b/src/Command/ListHandlerCommand.php
@@ -13,12 +13,25 @@ declare(strict_types=1);
 
 namespace Sonata\NotificationBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Sonata\NotificationBundle\Consumer\Metadata;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ListHandlerCommand extends ContainerAwareCommand
+class ListHandlerCommand extends Command
 {
+    /**
+     * @var Metadata
+     */
+    private $metadata;
+
+    public function __construct(Metadata $metadata)
+    {
+        parent::__construct(null);
+
+        $this->metadata = $metadata;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -34,20 +47,12 @@ class ListHandlerCommand extends ContainerAwareCommand
     public function execute(InputInterface $input, OutputInterface $output): void
     {
         $output->writeln('<info>List of consumers available</info>');
-        foreach ($this->getMetadata() as $type => $ids) {
+        foreach ($this->metadata->getInformations() as $type => $ids) {
             foreach ($ids as $id) {
                 $output->writeln(sprintf('<info>%s</info> - <comment>%s</comment>', $type, $id));
             }
         }
 
         $output->writeln(' done!');
-    }
-
-    /**
-     * @return array
-     */
-    private function getMetadata()
-    {
-        return $this->getContainer()->get('sonata.notification.consumer.metadata')->getInformations();
     }
 }

--- a/src/Command/ListQueuesCommand.php
+++ b/src/Command/ListQueuesCommand.php
@@ -13,13 +13,26 @@ declare(strict_types=1);
 
 namespace Sonata\NotificationBundle\Command;
 
+use Sonata\NotificationBundle\Backend\BackendInterface;
 use Sonata\NotificationBundle\Backend\QueueDispatcherInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ListQueuesCommand extends ContainerAwareCommand
+class ListQueuesCommand extends Command
 {
+    /**
+     * @var BackendInterface
+     */
+    private $backend;
+
+    public function __construct(BackendInterface $backend)
+    {
+        parent::__construct(null);
+
+        $this->backend = $backend;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -34,18 +47,16 @@ class ListQueuesCommand extends ContainerAwareCommand
      */
     public function execute(InputInterface $input, OutputInterface $output): void
     {
-        $backend = $this->getContainer()->get('sonata.notification.backend');
-
-        if (!$backend instanceof QueueDispatcherInterface) {
+        if (!$this->backend instanceof QueueDispatcherInterface) {
             $output->writeln(
-                'The backend class <info>'.\get_class($backend).'</info> does not provide multiple queues.'
+                'The backend class <info>'.\get_class($this->backend).'</info> does not provide multiple queues.'
             );
 
             return;
         }
 
         $output->writeln('<info>List of queues available</info>');
-        foreach ($backend->getQueues() as $queue) {
+        foreach ($this->backend->getQueues() as $queue) {
             $output->writeln(sprintf(
                 'queue: <info>%s</info> - routing_key: <info>%s</info>',
                 $queue['queue'],

--- a/src/Resources/config/command.xml
+++ b/src/Resources/config/command.xml
@@ -2,21 +2,31 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="Sonata\NotificationBundle\Command\ConsumerHandlerCommand" class="Sonata\NotificationBundle\Command\ConsumerHandlerCommand" public="true">
+            <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="sonata.notification.backend"/>
             <tag name="console.command"/>
         </service>
         <service id="Sonata\NotificationBundle\Command\CreateAndPublishCommand" class="Sonata\NotificationBundle\Command\CreateAndPublishCommand" public="true">
+            <argument type="service" id="sonata.notification.backend"/>
             <tag name="console.command"/>
         </service>
         <service id="Sonata\NotificationBundle\Command\ListHandlerCommand" class="Sonata\NotificationBundle\Command\ListHandlerCommand" public="true">
+            <argument type="service" id="sonata.notification.consumer.metadata"/>
             <tag name="console.command"/>
         </service>
         <service id="Sonata\NotificationBundle\Command\ListQueuesCommand" class="Sonata\NotificationBundle\Command\ListQueuesCommand" public="true">
+            <argument type="service" id="sonata.notification.backend"/>
             <tag name="console.command"/>
         </service>
         <service id="Sonata\NotificationBundle\Command\RestartCommand" class="Sonata\NotificationBundle\Command\RestartCommand" public="true">
+            <argument type="service" id="sonata.notification.backend"/>
+            <argument type="service" id="sonata.notification.erroneous_messages_selector"/>
+            <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="sonata.notification.manager.message"/>
             <tag name="console.command"/>
         </service>
         <service id="Sonata\NotificationBundle\Command\CleanupCommand" class="Sonata\NotificationBundle\Command\CleanupCommand" public="true">
+            <argument type="service" id="sonata.notification.backend"/>
             <tag name="console.command"/>
         </service>
     </services>

--- a/src/Resources/config/command.xml
+++ b/src/Resources/config/command.xml
@@ -18,13 +18,6 @@
             <argument type="service" id="sonata.notification.backend"/>
             <tag name="console.command"/>
         </service>
-        <service id="Sonata\NotificationBundle\Command\RestartCommand" class="Sonata\NotificationBundle\Command\RestartCommand" public="true">
-            <argument type="service" id="sonata.notification.backend"/>
-            <argument type="service" id="sonata.notification.erroneous_messages_selector"/>
-            <argument type="service" id="event_dispatcher"/>
-            <argument type="service" id="sonata.notification.manager.message"/>
-            <tag name="console.command"/>
-        </service>
         <service id="Sonata\NotificationBundle\Command\CleanupCommand" class="Sonata\NotificationBundle\Command\CleanupCommand" public="true">
             <argument type="service" id="sonata.notification.backend"/>
             <tag name="console.command"/>

--- a/src/Resources/config/doctrine_orm.xml
+++ b/src/Resources/config/doctrine_orm.xml
@@ -6,5 +6,12 @@
             <argument>%sonata.notification.message.class%</argument>
             <argument type="service" id="doctrine"/>
         </service>
+        <service id="Sonata\NotificationBundle\Command\RestartCommand" class="Sonata\NotificationBundle\Command\RestartCommand" public="true">
+            <argument type="service" id="sonata.notification.backend"/>
+            <argument type="service" id="sonata.notification.erroneous_messages_selector"/>
+            <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="sonata.notification.manager.message"/>
+            <tag name="console.command"/>
+        </service>
     </services>
 </container>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting master, because the branch 3.x don't provide SF5 support.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #464.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNotificationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Commands no longer inject itself the container

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
