### PR TITLE
Remove deprecated phpunit calls

### DIFF
--- a/tests/Backend/AMQPBackendTest.php
+++ b/tests/Backend/AMQPBackendTest.php
@@ -107,12 +107,12 @@ class AMQPBackendTest extends TestCase
         $deadLetterTopic = new ImplAmqpTopic(self::DEAD_LETTER_EXCHANGE);
 
         $contextMock = $this->createMock(AmqpContext::class);
-        $contextMock->expects($this->at(0))
+        $contextMock->expects($this->once())
             ->method('createQueue')
             ->with($this->identicalTo(self::QUEUE))
             ->willReturn($queue);
 
-        $contextMock->expects($this->at(1))
+        $contextMock->expects($this->once())
             ->method('declareQueue')
             ->with($this->identicalTo($queue))
             ->willReturnCallback(function (AmqpQueue $queue) {
@@ -120,31 +120,25 @@ class AMQPBackendTest extends TestCase
                 $this->assertSame(['x-dead-letter-exchange' => self::DEAD_LETTER_EXCHANGE], $queue->getArguments());
             });
 
-        $contextMock->expects($this->at(2))
+        $contextMock->expects($this->exactly(2))
             ->method('createTopic')
-            ->with($this->identicalTo(self::EXCHANGE))
-            ->willReturn($topic);
+            ->willReturnMap([
+                [self::EXCHANGE, $topic],
+                [self::DEAD_LETTER_EXCHANGE, $deadLetterTopic],
+            ]);
 
-        $contextMock->expects($this->at(3))
-            ->method('declareTopic')
-            ->with($this->identicalTo($topic));
-
-        $contextMock->expects($this->at(4))
+        $contextMock->expects($this->atLeastOnce())
             ->method('bind')
             ->with($this->isInstanceOf(AmqpBind::class));
 
-        $contextMock->expects($this->at(5))
-            ->method('createTopic')
-            ->with($this->identicalTo(self::DEAD_LETTER_EXCHANGE))
-            ->willReturn($deadLetterTopic);
-
-        $contextMock->expects($this->at(6))
+        $contextMock->expects($this->exactly(2))
             ->method('declareTopic')
-            ->with($this->identicalTo($deadLetterTopic))
-            ->willReturnCallback(function (AmqpTopic $topic) {
-                $this->assertTrue((bool) ($topic->getFlags() & AmqpTopic::FLAG_DURABLE));
-                $this->assertSame(AmqpTopic::TYPE_DIRECT, $topic->getType());
-                $this->assertSame([], $topic->getArguments());
+            ->willReturnCallback(function (AmqpTopic $topic) use ($deadLetterTopic) {
+                if ($topic === $deadLetterTopic) {
+                    $this->assertTrue((bool) ($topic->getFlags() & AmqpTopic::FLAG_DURABLE));
+                    $this->assertSame(AmqpTopic::TYPE_DIRECT, $topic->getType());
+                    $this->assertSame([], $topic->getArguments());
+                }
             });
 
         AmqpConnectionFactoryStub::$context = $contextMock;
@@ -158,15 +152,14 @@ class AMQPBackendTest extends TestCase
 
         $queue = new ImplAmqpQueue(self::QUEUE);
         $topic = new ImplAmqpTopic(self::EXCHANGE);
-        $deadLetterTopic = new ImplAmqpTopic(self::DEAD_LETTER_EXCHANGE);
 
         $contextMock = $this->createMock(AmqpContext::class);
-        $contextMock->expects($this->at(0))
+        $contextMock->expects($this->once())
             ->method('createQueue')
             ->with($this->identicalTo(self::QUEUE))
             ->willReturn($queue);
 
-        $contextMock->expects($this->at(1))
+        $contextMock->expects($this->once())
             ->method('declareQueue')
             ->with($this->identicalTo($queue))
             ->willReturnCallback(function (AmqpQueue $queue) {
@@ -180,16 +173,16 @@ class AMQPBackendTest extends TestCase
                 );
             });
 
-        $contextMock->expects($this->at(2))
+        $contextMock->expects($this->once())
             ->method('createTopic')
             ->with($this->identicalTo(self::EXCHANGE))
             ->willReturn($topic);
 
-        $contextMock->expects($this->at(3))
+        $contextMock->expects($this->once())
             ->method('declareTopic')
             ->with($this->identicalTo($topic));
 
-        $contextMock->expects($this->at(4))
+        $contextMock->expects($this->once())
             ->method('bind')
             ->with($this->isInstanceOf(AmqpBind::class));
 

--- a/tests/Iterator/IteratorProxyMessageIteratorTest.php
+++ b/tests/Iterator/IteratorProxyMessageIteratorTest.php
@@ -23,64 +23,15 @@ class IteratorProxyMessageIteratorTest extends TestCase
 {
     public function testIteratorProxiesIteratorMethods(): void
     {
-        $content = [
+        $actualIterator = new \ArrayIterator([
             'foo',
             'bar',
-        ];
-
-        $actualIterator = $this->createMock('Iterator');
-        $this->expectIterator($actualIterator, $content, true);
+        ]);
 
         $proxy = new IteratorProxyMessageIterator($actualIterator);
         foreach ($proxy as $eachKey => $eachEntry) {
             $this->assertNotNull($eachKey);
             $this->assertNotEmpty($eachEntry);
         }
-    }
-
-    /**
-     * @see https://gist.github.com/2852498
-     */
-    public function expectIterator($mock, array $content, $withKey = false, $counter = 0): int
-    {
-        $mock
-            ->expects($this->at($counter))
-            ->method('rewind')
-        ;
-
-        foreach ($content as $key => $value) {
-            $mock
-                ->expects($this->at(++$counter))
-                ->method('valid')
-                ->willReturn(true)
-            ;
-
-            $mock
-                ->expects($this->at(++$counter))
-                ->method('current')
-                ->willReturn($value)
-            ;
-
-            if ($withKey) {
-                $mock
-                    ->expects($this->at(++$counter))
-                    ->method('key')
-                    ->willReturn($key)
-                ;
-            }
-
-            $mock
-                ->expects($this->at(++$counter))
-                ->method('next')
-            ;
-        }
-
-        $mock
-            ->expects($this->at(++$counter))
-            ->method('valid')
-            ->willReturn(false)
-        ;
-
-        return ++$counter;
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is pedantic.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
