### PR TITLE
Some fixes

### DIFF
--- a/src/Admin/MessageAdmin.php
+++ b/src/Admin/MessageAdmin.php
@@ -60,9 +60,9 @@ class MessageAdmin extends AbstractAdmin
     /**
      * {@inheritdoc}
      */
-    protected function configureShowFields(ShowMapper $showMapper)
+    protected function configureShowFields(ShowMapper $show)
     {
-        $showMapper
+        $show
             ->add('id')
             ->add('type')
             ->add('createdAt')
@@ -77,9 +77,9 @@ class MessageAdmin extends AbstractAdmin
     /**
      * {@inheritdoc}
      */
-    protected function configureListFields(ListMapper $listMapper)
+    protected function configureListFields(ListMapper $list)
     {
-        $listMapper
+        $list
             ->addIdentifier('id', null, ['route' => ['name' => 'show']])
             ->add('type')
             ->add('createdAt')
@@ -93,11 +93,11 @@ class MessageAdmin extends AbstractAdmin
     /**
      * {@inheritdoc}
      */
-    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+    protected function configureDatagridFilters(DatagridMapper $filter)
     {
         $class = $this->getClass();
 
-        $datagridMapper
+        $filter
             ->add('type')
             ->add('state', null, [], ChoiceType::class, ['choices' => $class::getStateList()])
         ;

--- a/src/Backend/PostponeRuntimeBackend.php
+++ b/src/Backend/PostponeRuntimeBackend.php
@@ -16,7 +16,6 @@ namespace Sonata\NotificationBundle\Backend;
 use Laminas\Diagnostics\Result\Success;
 use Sonata\NotificationBundle\Iterator\IteratorProxyMessageIterator;
 use Sonata\NotificationBundle\Model\MessageInterface;
-use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -74,7 +73,7 @@ class PostponeRuntimeBackend extends RuntimeBackend
      * Actually, an event is not necessary, you can call this method manually, to.
      * The event is not processed in any way.
      */
-    public function onEvent(?Event $event = null)
+    public function onEvent()
     {
         while (!empty($this->messages)) {
             $message = array_shift($this->messages);

--- a/src/Controller/Api/MessageController.php
+++ b/src/Controller/Api/MessageController.php
@@ -153,7 +153,7 @@ class MessageController
     {
         $message = null;
 
-        $form = $this->formFactory->createNamed(null, 'sonata_notification_api_form_message', $message, [
+        $form = $this->formFactory->createNamed('', 'sonata_notification_api_form_message', $message, [
             'csrf_protection' => false,
         ]);
 

--- a/src/Entity/MessageManager.php
+++ b/src/Entity/MessageManager.php
@@ -25,14 +25,14 @@ class MessageManager extends BaseEntityManager implements MessageManagerInterfac
     /**
      * {@inheritdoc}
      */
-    public function save($message, $andFlush = true)
+    public function save($entity, $andFlush = true)
     {
         //Hack for ConsumerHandlerCommand->optimize()
-        if ($message->getId() && !$this->em->getUnitOfWork()->isInIdentityMap($message)) {
-            $message = $this->getEntityManager()->getUnitOfWork()->merge($message);
+        if ($entity->getId() && !$this->em->getUnitOfWork()->isInIdentityMap($entity)) {
+            $entity = $this->getEntityManager()->getUnitOfWork()->merge($entity);
         }
 
-        parent::save($message, $andFlush);
+        parent::save($entity, $andFlush);
     }
 
     /**

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -81,12 +81,12 @@ final class AppKernel extends Kernel
         }
     }
 
-    protected function configureContainer(ContainerBuilder $containerBuilder, LoaderInterface $loader): void
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
         $loader->load(__DIR__.'/Resources/config/config.yml');
         $loader->load(__DIR__.'/Resources/config/security.yml');
 
-        $containerBuilder->setParameter('app.base_dir', $this->getBaseDir());
+        $container->setParameter('app.base_dir', $this->getBaseDir());
     }
 
     private function getBaseDir(): string

--- a/tests/Backend/BackendHealthCheckTest.php
+++ b/tests/Backend/BackendHealthCheckTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Sonata\NotificationBundle\Tests\Notification;
+namespace Sonata\NotificationBundle\Tests\Backend;
 
 use Laminas\Diagnostics\Result\Success;
 use PHPUnit\Framework\TestCase;

--- a/tests/Backend/MessageManagerBackendTest.php
+++ b/tests/Backend/MessageManagerBackendTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Sonata\NotificationBundle\Tests\Notification;
+namespace Sonata\NotificationBundle\Tests\Backend;
 
 use Laminas\Diagnostics\Result\Failure;
 use Laminas\Diagnostics\Result\Success;

--- a/tests/Backend/RuntimeBackendTest.php
+++ b/tests/Backend/RuntimeBackendTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Sonata\NotificationBundle\Tests\Notification;
+namespace Sonata\NotificationBundle\Tests\Backend;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\NotificationBundle\Backend\RuntimeBackend;

--- a/tests/Entity/MessageManagerMock.php
+++ b/tests/Entity/MessageManagerMock.php
@@ -45,7 +45,7 @@ class MessageManagerMock extends MessageManager
         return $result;
     }
 
-    public function save($message, $andFlush = true)
+    public function save($entity, $andFlush = true)
     {
     }
 }

--- a/tests/Event/DoctrineOptimizeListenerTest.php
+++ b/tests/Event/DoctrineOptimizeListenerTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Sonata\NotificationBundle\Tests\Entity;
+namespace Sonata\NotificationBundle\Tests\Event;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\UnitOfWork;

--- a/tests/Functional/RoutingTest.php
+++ b/tests/Functional/RoutingTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Sonata\NotificationBundle\Tests\Functional\Routing;
+namespace Sonata\NotificationBundle\Tests\Functional;
 
 use Nelmio\ApiDocBundle\Annotation\Operation;
 use Sonata\NotificationBundle\Tests\App\AppKernel;


### PR DESCRIPTION
I think this can be considered pedantic.

~The visibility of `configure` and `execute` has been changed in commands to match the one from the parent. It is BC break, but I think this is fine as people should not call those methods manually~ (EDIT: We'll do it in `master`).

Removing `?Event $event = null` is not BC break: https://3v4l.org/u4R91