### PR TITLE
Fix message admin

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,11 +36,11 @@ jobs:
                       dependencies: lowest
                       allowed-to-fail: false
                       variant: normal
-                    - php-version: '7.4'
+                    - php-version: '8.0'
                       dependencies: highest
                       allowed-to-fail: false
                       variant: 'symfony/symfony:"4.4.*"'
-                    - php-version: '7.4'
+                    - php-version: '8.0'
                       dependencies: highest
                       allowed-to-fail: false
                       variant: 'symfony/symfony:"5.2.*"'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,11 @@ jobs:
                       dependencies: lowest
                       allowed-to-fail: false
                       variant: normal
-                    - php-version: '8.0'
+                    - php-version: '7.4'
+                      dependencies: highest
+                      allowed-to-fail: false
+                      variant: 'symfony/symfony:"4.4.*"'
+                    - php-version: '7.4'
                       dependencies: highest
                       allowed-to-fail: false
                       variant: 'symfony/symfony:"5.2.*"'

--- a/composer.json
+++ b/composer.json
@@ -45,9 +45,9 @@
         "jms/serializer": "<0.13",
         "liip/monitor-bundle": "<1.0",
         "nelmio/api-doc-bundle": "<2.13 || >=4.0",
-        "sonata-project/admin-bundle": "<3.1",
+        "sonata-project/admin-bundle": "<4.0",
         "sonata-project/core-bundle": "<3.20",
-        "sonata-project/doctrine-orm-admin-bundle": "<3.0"
+        "sonata-project/doctrine-orm-admin-bundle": "<4.0"
     },
     "require-dev": {
         "enqueue/amqp-lib": "^0.8",

--- a/src/Admin/MessageAdmin.php
+++ b/src/Admin/MessageAdmin.php
@@ -24,9 +24,6 @@ class MessageAdmin extends AbstractAdmin
 {
     protected $classnameLabel = 'Message';
 
-    /**
-     * {@inheritdoc}
-     */
     public function configureRoutes(RouteCollectionInterface $collection): void
     {
         $collection
@@ -36,12 +33,8 @@ class MessageAdmin extends AbstractAdmin
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getBatchActions(): array
+    protected function configureBatchActions($actions): array
     {
-        $actions = [];
         $actions['publish'] = [
             'label' => $this->getLabelTranslatorStrategy()->getLabel('publish', 'batch', 'message'),
             'translation_domain' => $this->getTranslationDomain(),
@@ -57,9 +50,6 @@ class MessageAdmin extends AbstractAdmin
         return $actions;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function configureShowFields(ShowMapper $show): void
     {
         $show
@@ -74,9 +64,6 @@ class MessageAdmin extends AbstractAdmin
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function configureListFields(ListMapper $list): void
     {
         $list
@@ -90,16 +77,16 @@ class MessageAdmin extends AbstractAdmin
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function configureDatagridFilters(DatagridMapper $filter): void
     {
         $class = $this->getClass();
 
         $filter
             ->add('type')
-            ->add('state', null, [], ChoiceType::class, ['choices' => $class::getStateList()])
+            ->add('state', null, [
+                'field_type' => ChoiceType::class,
+                'field_options' => ['choices' => $class::getStateList()],
+            ])
         ;
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This PR will fix working with `MessageAdmin` and mistake from https://github.com/sonata-project/SonataNotificationBundle/pull/559 
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNotificationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added some `Class::newMethod()` to do great stuff.

### Changed

### Deprecated

### Removed

### Fixed

### Security
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
