### PR TITLE
Update constraints in order to allow some "symfony/*:^5.2" deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,14 +28,14 @@
         "sonata-project/datagrid-bundle": "^3.0",
         "sonata-project/doctrine-extensions": "^1.10.1",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
-        "symfony/config": "^4.4",
+        "symfony/config": "^4.4 || ^5.2",
         "symfony/console": "^4.4",
-        "symfony/dependency-injection": "^4.4",
+        "symfony/dependency-injection": "^4.4 || ^5.2",
         "symfony/doctrine-bridge": "^4.4",
         "symfony/event-dispatcher": "^4.4",
         "symfony/event-dispatcher-contracts": "^1.1",
         "symfony/form": "^4.4",
-        "symfony/http-foundation": "^4.4",
+        "symfony/http-foundation": "^4.4 || ^5.2",
         "symfony/http-kernel": "^4.4",
         "symfony/security-core": "^4.4"
     },
@@ -59,11 +59,11 @@
         "nelmio/api-doc-bundle": "^2.13.4 || ^3.6",
         "sonata-project/doctrine-orm-admin-bundle": "^3.19",
         "swiftmailer/swiftmailer": "^5.0 || ^6.0",
-        "symfony/browser-kit": "^4.4 || ^5.1",
-        "symfony/phpunit-bridge": "^5.1.8",
+        "symfony/browser-kit": "^4.4 || ^5.2",
+        "symfony/phpunit-bridge": "^5.2",
         "symfony/swiftmailer-bundle": "^3.4",
-        "symfony/templating": "^4.4",
-        "symfony/yaml": "^4.4"
+        "symfony/templating": "^4.4 || ^5.2",
+        "symfony/yaml": "^4.4 || ^5.2"
     },
     "suggest": {
         "guzzlehttp/guzzle": "If you want to get a status report when using the rabbitMQ backend.",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Update constraints in order to allow some "symfony/*:^5.2" deps.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Support for "symfony/config:^5.2";
- Support for "symfony/dependency-injection:^5.2";
- Support for "symfony/http-foundation:^5.2".
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
