### PR TITLE
Make some services private

### DIFF
--- a/src/Resources/config/admin.xml
+++ b/src/Resources/config/admin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sonata.notification.admin.message" class="%sonata.notification.admin.message.class%" public="true">
+        <service id="sonata.notification.admin.message" class="%sonata.notification.admin.message.class%">
             <tag name="sonata.admin" manager_type="orm" group="sonata_notification" label="notifications" label_catalogue="%sonata.notification.admin.message.translation_domain%" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
             <argument/>
             <argument>%sonata.notification.admin.message.entity%</argument>

--- a/src/Resources/config/selector.xml
+++ b/src/Resources/config/selector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sonata.notification.erroneous_messages_selector" class="Sonata\NotificationBundle\Selector\ErroneousMessagesSelector" public="true">
+        <service id="sonata.notification.erroneous_messages_selector" class="Sonata\NotificationBundle\Selector\ErroneousMessagesSelector">
             <argument type="service" id="doctrine"/>
             <argument>%sonata.notification.message.class%</argument>
         </service>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because in this branch the services don't need to be public anymore.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #464.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNotificationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Changed `sonata.notification.erroneous_messages_selector` service to be private
- Changed `sonata.notification.admin.message` service to be private
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
